### PR TITLE
Basic unicode input support

### DIFF
--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -142,6 +142,7 @@ SDL20_SYM(SDL_bool,PixelFormatEnumToMasks,(Uint32 a,int *b,Uint32 *c,Uint32 *d,U
 
 SDL20_SYM_PASSTHROUGH(void,SetModState,(SDL_Keymod a),(a),)
 SDL20_SYM_PASSTHROUGH(SDL_Keymod,GetModState,(void),(),return)
+SDL20_SYM(void,StartTextInput,(void),(),)
 SDL20_SYM(void,StopTextInput,(void),(),)
 
 SDL20_SYM(Uint32,GetMouseState,(int *a, int *b),(a,b),return)


### PR DESCRIPTION
This change adds unicode input support via the `SDL_TEXTINPUT` events.

These are turned into a number of new `KEYDOWN` events, one per input character. These generated events all have a sym of `SDLK_UNKNOWN,` so shouldn't register as spurious keyboard inputs. Normal key messages (i.e., those which did not originate with an `SDL_TEXTINPUT` event) now have a `unicode` value of 0 all the time.

It's not perfect yet (see below), but seems to be an improvement over just using the `keysym.sym` value, which didn't support things like using Shift to get uppercase letters.

Note that this also includes a basic UTF-8 decoder, which depends on  `SDL_MostSignificantBitIndex32()`. Since it's force-inlined, 

It also doesn't yet support codepoints greater than 0xFFFF, as we don't yet generate surrogate pairs.

I've tested this against a couple of different games (Defcon and Psychonauts), and input works. This also includes using the compose key to input accented characters and IBUS for more complicated input (including having several characters being input as part of the same event). While CJK characters weren't working (likely due to the UTF-16 surrogate pair issue), and there were issues with some games which have limited font support or similar, it seems to work a little better than I expected so far.