### PR TITLE
SDL_ListModes: Treat formats with the same bpp as though they are identical

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -2794,7 +2794,7 @@ SDL_ListModes(const SDL12_PixelFormat *format12, Uint32 flags)
 
     for (i = 0; i < VideoModesCount; i++) {
         VideoModeList *modes = &VideoModes[i];
-        if (modes->format == fmt) {
+        if (SDL_BITSPERPIXEL(modes->format) == SDL_BITSPERPIXEL(fmt)) {
             return modes->modes12;
         }
     }


### PR DESCRIPTION
Some games do some interesting things with `SDL_ListModes()`, `SDL_VideoModeOK()` and similar in order to choose and/or validate video modes.

In particular, [Darwinia, Defcon, and Multiwinia](https://www.introversion.co.uk/introversion/) all take the desktop mode's format (via `SDL_GetVideoInfo()->vfmt`), replace the `BitsPerPixel` field with their desired bpp, and then validate that `SDL_ListModes()` returns a list of modes. (They then goes on to verify the mode it selects with SDL_VideoModeOK(), and very aggressively falls back to 800×600 windowed at 16-bit. This is particularly annoying for Darwinia and Defcon, which need a restart after every mode change.)

With sdl12-compat, this never yields a valid mode under X11. By just checking if there's a mode with the same bit depth (which, after all, is what the game is really asking for), then — under X11 and XWayland — 24bpp modes are working fine. 32 and 16 bpp modes aren't, which is still a regression from SDL 1.2, but at least _something_ works.

Note the SDL 1.2 is much more lenient still, at least under X11, where there is only one list of modes (as X11 can't change bit depths at runtime), and it is returned whenever the format has the same bpp as any valid visual.

Indeed SDL 1.2 seems to have a lot more explicit support for falling back to different bit-depths (and emulating the desired mode if necessary). Given these games are OpenGL-based, even that isn't necessary for them. Maybe adding some more of these fallbacks (inside `SDL_VideoModeOK()` as well) would result in behaviour which is more similar to the real SDL 1.2.