### PR TITLE
Handle SDL_WM_GrabInput() when VideoSurface12 is NULL

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -4124,7 +4124,8 @@ static void
 HandleInputGrab(SDL12_GrabMode mode)
 {
     /* SDL 1.2 always grabbed input if the video mode was fullscreen. */
-    const SDL_bool wantgrab = ((VideoSurface12->flags & SDL12_FULLSCREEN) || (mode == SDL12_GRAB_ON)) ? SDL_TRUE : SDL_FALSE;
+    const SDL_bool isfullscreen = (VideoSurface12 && (VideoSurface12->flags & SDL12_FULLSCREEN)) ? SDL_TRUE : SDL_FALSE;
+    const SDL_bool wantgrab = (isfullscreen || (mode == SDL12_GRAB_ON)) ? SDL_TRUE : SDL_FALSE;
     if (VideoWindowGrabbed != wantgrab) {
         SDL20_SetWindowGrab(VideoWindow20, wantgrab);
         VideoWindowGrabbed = wantgrab;


### PR DESCRIPTION
It's possible for ``HandleInputGrab()`` — which is called by ``SDL_WM_GrabInput()`` — to dereference a NULL pointer when attempting to check if the window is fullscreen. Assume that, if ``VideoSurface12`` is NULL, we don't have a fullscreen window, and so shouldn't automatically grab.


This was causing Psychonauts to crash on startup, as it called ``SDL_WM_GrabInput()`` before ``SDL_SetVideoMode()``.