### PR TITLE
Install development headers and compatible pkgconfig file with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,12 @@
 #        cmake -DSDL2_INCLUDE_DIR=/opt/SDL2/include/SDL2 [other stuff]
 
 cmake_minimum_required(VERSION 3.0.0)
-project(sdl12_compat)
+project(sdl12_compat
+        VERSION 0.0.1
+        LANGUAGES C)
 
 option(SDL12TESTS "Enable to build SDL-1.2 test programs" ON)
+option(SDL12DEVEL "Enable installing SDL-1.2 development headers" ON)
 
 set(CMAKE_SKIP_RPATH TRUE)
 
@@ -140,3 +143,12 @@ endif()
 install(TARGETS SDL
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(SDL12DEVEL)
+  install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+  configure_file(sdl12_compat.pc.in sdl12_compat.pc @ONLY)
+  install(FILES ${CMAKE_BINARY_DIR}/sdl12_compat.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  )
+endif()

--- a/sdl12_compat.pc.in
+++ b/sdl12_compat.pc.in
@@ -1,0 +1,14 @@
+# sdl12_compat pkg-config source file
+
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: sdl12_compat
+Description: An SDL-1.2 compatibility layer that uses SDL 2.0 behind the scenes.
+Version: @PROJECT_VERSION@
+Provides: sdl = 1.2.50
+Libs: -L${libdir}  -lSDL  -lpthread
+Libs.private: -lSDL  -lpthread  -lm -ldl -lpthread
+Cflags: -I${includedir}/SDL -D_GNU_SOURCE=1 -D_REENTRANT


### PR DESCRIPTION
In order to fully substitute for SDL 1.2, we need to be able to
install the headers and generate a compatible .pc (pkgconfig) file.

There's an option to not install it if it is not desired for some
reason.

Reference: https://fedoraproject.org/wiki/Changes/SDL12onSDL2