### PR TITLE
Use scaled mouse coordinates from SDL_RenderSetLogicalSize()

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1477,7 +1477,7 @@ Init12Video(void)
     SDL20_memset(EventStates, SDL_ENABLE, sizeof (EventStates)); /* on by default */
     EventStates[SDL12_SYSWMEVENT] = SDL_IGNORE;  /* off by default. */
 
-    SDL20_SetEventFilter(EventFilter20to12, NULL);
+    SDL20_AddEventWatch(EventFilter20to12, NULL);
 
     VideoDisplayIndex = GetVideoDisplay();
     SwapInterval = 0;
@@ -3518,6 +3518,11 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
         }
 
         SDL20_RenderSetLogicalSize(VideoRenderer20, width, height);
+
+        /* we need to make sure we're at the back of the Event Watch queue */	
+        SDL20_DelEventWatch(EventFilter20to12, NULL);
+        SDL20_AddEventWatch(EventFilter20to12, NULL);
+
         SDL20_SetRenderDrawColor(VideoRenderer20, 0, 0, 0, 255);  /* leave this black always, we only use it to clear the framebuffer. */
         SDL20_RenderClear(VideoRenderer20);
         SDL20_RenderPresent(VideoRenderer20);

--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -65,6 +65,8 @@ SDL20_SYM(SDL_assert_state,ReportAssertion,(SDL_assert_data *a,const char *b,con
 SDL20_SYM(int,PollEvent,(SDL_Event *a),(a),return)
 SDL20_SYM(void,PumpEvents,(void),(),)
 SDL20_SYM(void,SetEventFilter,(SDL_EventFilter a, void *b),(a,b),)
+SDL20_SYM(void,AddEventWatch,(SDL_EventFilter a, void *b),(a,b),)
+SDL20_SYM(void,DelEventWatch,(SDL_EventFilter a, void *b),(a,b),)
 
 SDL20_SYM(int,GetNumDisplayModes,(int a),(a),return)
 SDL20_SYM(int,GetDisplayMode,(int a, int b, SDL_DisplayMode *c),(a,b,c),return)


### PR DESCRIPTION
While sdl12-compat scales the graphics for fullscreen windows running at a non-native resolution, mouse input is not scaled to match. Most games handle this relatively well — maybe the mouse gets "lost" off the right or bottom corners of the screen, which is only really obvious on dual-screen setups — but some will end up with the system/hardware cursor offset from where the game thinks it is.

For non-OpenGL applications, ``SDL_RenderSetLogicalSize()`` should scale the mouse coordinates for the window's events for us, but this has two problems:
1. We use ``SDL_SetEventFilter()`` to receive events, which runs before the Event Watch callback used by SDL_Renderer to scale the input.
2. Only events for the particular window are affected: the global coordinates returned by ``SDL_GetMouseState()`` aren't.

This PR switches to using ``SDL_AddEventWatch()`` (and updates it after ``SDL_RenderSetLogicalSize()`` to ensure it's always last on the list of watchers), and makes ``SDL_GetMouseState()`` return cached coordinates from event processing.

For OpenGL applications, none of this works because ``SDL_RenderSetLogicalSize()`` isn't being used, so maybe the correct way to do this is to scale mouse coordinates manually. This PR doesn't attempt to implement that, though. If we did wish to manually scale coordinates, we could either do so for both non-OpenGL windows and OpenGL windows (discarding these changes), or just do so for OpenGL windows. Both options seem reasonably sensible to me, so it's a matter of taste.

I've tested this with [Long Live The Queen](https://www.hanakogames.com/llq.shtml), which uses an SDL1.2/pygame-based RenPy engine — I expect other RenPy games of a similar age will behave similarly. Most of the other games I usually test are OpenGL-based, so aren't fixed by this.

Does this seem like a sensible approach?