### PR TITLE
SDL_SetAlpha() shouldn't fail on surfaces with alpha channels

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -3808,7 +3808,7 @@ SDL_SetAlpha(SDL12_Surface *surface12, Uint32 flags12, Uint8 value)
 {
     /* note that SDL 1.2 does not check if surface12 is NULL before dereferencing it either */
     const SDL_bool addkey = (flags12 & SDL12_SRCALPHA) ? SDL_TRUE : SDL_FALSE;
-    int retval = -1;
+    int retval = 0;
 
     if (addkey) {
         if (!surface12->format->Amask) {  /* whole-surface alpha is ignored if surface has an alpha channel. */


### PR DESCRIPTION
While ``SDL_SetAlpha()`` should ignore the "whole-surface alpha" value, it should still succeed for surfaces which have an alpha channel.

Commit b4acf4f08f implements this, but returns -1 for surfaces with an alpha channel, signaling an error. Given that we've actually successfully enabled/disabled blending, ``SDL_SetAlpha()`` has succeeded, even if a whole-channel alpha value wasn't set.

In fact, SDL 1.2 seems to never be able to return an error from ``SDL_SetAlpha()``.

This fixes Ren'py games, which use ``SDL_SetAlpha()`` on surfaces with an alpha channel, and check the return value. In particular, the Steam version of "Long Live the Queen", which uses Ren'py 6.12.2, broke in b4acf4f08f, and is fixed by this. ``testalpha`` seems to still work fine with this change, too. 