### PR TITLE
Don't set SDL_DOUBLEBUF on the screen surface

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -3584,7 +3584,6 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
         }
 
         VideoSurface12->flags &= ~SDL12_OPENGL;
-        VideoSurface12->flags |= SDL12_DOUBLEBUF;
         VideoSurface12->surface20->pixels = SDL20_malloc(height * VideoSurface12->pitch);
         VideoSurface12->pixels = VideoSurface12->surface20->pixels;
         if (!VideoSurface12->pixels) {


### PR DESCRIPTION
This causes problems with programs which don't handle the combination of ``SDL_DOUBLEBUF`` on a surface which doesn't need locking (i.e. ``SDL_HWSURFACE`` not being set) properly.

DOSBox is one such application, so this fixes issue #58.

It also matches what the real SDL 1.2 exposes in most real-world circumstances.

Tested this against DOSBox (now works), Ren'py 6.12 /Long Live The Queen (continues to work), and ``testsprite`` (continues to work).