### PR TITLE
Fix a couple of compile warnings (and a bug) in SDL 1.2 test programs

### DIFF
--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 		SDL_UnloadObject(lib);
 	}
 	SDL_Quit();
-	return(0);
+	return retval;
 }
 
 

--- a/test/testoverlay.c
+++ b/test/testoverlay.c
@@ -321,7 +321,6 @@ static void PrintUsage(char *argv0)
 int main(int argc, char **argv)
 {
 	char *argv0 = argv[0];
-	int flip;
 	int delay;
 	int desired_bpp;
 	Uint32 video_flags, overlay_format;
@@ -332,7 +331,6 @@ int main(int argc, char **argv)
 	int i;
 
 	/* Set default options and check command-line */
-	flip = 0;
 	scale=0;
         monochrome=0;
         luminance=100;
@@ -473,7 +471,6 @@ int main(int argc, char **argv)
 			(screen->flags&SDL_HWSURFACE) ? "video" : "system");
 	if ( screen->flags & SDL_DOUBLEBUF ) {
 		printf("Double-buffering enabled\n");
-		flip = 1;
 	}
 
 	/* Set the window manager title bar */


### PR DESCRIPTION
I'm not sure when we want to modify these from their original SDL 1.2 forms, but since there seem to have been some changes, here are fixes for the warnings I get on my machine.

In ``testoverlay``, the ``flip`` variable is never read from: the ``-flip`` option just requests ``SDL_DOUBLEBUF``. It's a useless variable, but not actively harming anything. This change just gets rid of the variable.
```
/home/david/Development/sdl12-compat/test/testoverlay.c: In function ‘main’:
/home/david/Development/sdl12-compat/test/testoverlay.c:324:6: warning: variable ‘flip’ set but not used [-Wunused-but-set-variable]
  324 |  int flip;
      |      ^~~~
```

In ``testloadso``, the return value variable ``retval`` is also never read from: ``main`` just returns 0 at the end, regardless of whether it's succeeded or failed. (There are some error returns earlier in the file.) This seems to actually be a bug, so return ``retval`` instead.
```
/home/david/Development/sdl12-compat/test/testloadso.c: In function ‘main’:
/home/david/Development/sdl12-compat/test/testloadso.c:14:6: warning: variable ‘retval’ set but not used [-Wunused-but-set-variable]
   14 |  int retval = 0;
      |      ^~~~~~
```