### PR TITLE
Propagate KEY{UP,DOWN} even if keycode is SDLK_UNKNOWN

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -2647,9 +2647,6 @@ EventFilter20to12(void *data, SDL_Event *event20)
                 return 1;  /* ignore 2.0-style key repeat events */
             }
             event12.key.keysym.sym = Keysym20to12(event20->key.keysym.sym);
-            if (event12.key.keysym.sym == SDLK12_UNKNOWN) {
-                return 1;  /* drop it if we can't map it */
-            }
 
             KeyState[event12.key.keysym.sym] = event20->key.state;
 
@@ -2672,9 +2669,6 @@ EventFilter20to12(void *data, SDL_Event *event20)
             }
 
             PendingKeydownEvent.key.keysym.sym = Keysym20to12(event20->key.keysym.sym);
-            if (PendingKeydownEvent.key.keysym.sym == SDLK12_UNKNOWN) {
-                return 1;  /* drop it if we can't map it */
-            }
 
             KeyState[PendingKeydownEvent.key.keysym.sym] = event20->key.state;
 


### PR DESCRIPTION
Now that we have scancode and unicode values available, it's worth actually handling keys which might not have an SDLK_ value in SDL 1.2.

The motivating case here is DOSBox — see issue #84 — which uses scancodes for input by default. On some keyboard layouts, there are keys which have a valid scancode, but don't have a corresponding ``SDLK_`` value. For example, the 'ğ' key on the Turkish F layout sits where 'e' is on a US layout. There's no ``SDLK_ğ`` value for this to use, but the scancode is the same as for ``e``, so DOSBox should work anyway. However, the whole event is thrown out when the sym is ``SDLK_UNKNOWN``, so it never sees the scancode.

Note that this shouldn't really be a problem anyway, as SDL 1.2 — at least on my system — doesn't take the keyboard layout into consideration anyway, and provides US layout values for ``keysym.sym`` anyway. So, in this example, ``sym`` nevertheless would be ``SDLK_e``. So the other fix for this would be to convert SDL 2.0 scancodes to SDL 1.2 Keycodes instead of using the translated SDL 2.0 Keycodes. I think it nevertheless makes sense to pass through unknown keysyms, so we should do both.