### PR TITLE
checkkeys: Unconditionally display the scancode

### DIFF
--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -54,10 +54,10 @@ static void PrintKey(SDL_keysym *sym, int pressed)
 {
 	/* Print the keycode, name and state */
 	if ( sym->sym ) {
-		printf("Key %s:  %d-%s ", pressed ?  "pressed" : "released",
-					sym->sym, SDL_GetKeyName(sym->sym));
+		printf("Key %s:  %d-%s (scancode = %d [0x%x])", pressed ?  "pressed" : "released",
+					sym->sym, SDL_GetKeyName(sym->sym), sym->scancode, sym->scancode);
 	} else {
-		printf("Unknown Key (scancode = %d) %s ", sym->scancode,
+		printf("Unknown Key (scancode = %d [0x%x]) %s ", sym->scancode, sym->scancode,
 					pressed ?  "pressed" : "released");
 	}
 


### PR DESCRIPTION
It's useful for debugging what scancodes are used by SDL 1.2
(particularly across different platforms) if checkkeys displays it even
when it does successfully map it to an SDLKey.

In addition, print the scancode in hex as well as decimal, as the
hardcoded values we're using in sdl12-compat are all in hex.

Previously (for pressing 'a' and the 'Calculator' key on my keyboard), ``checkkeys`` would show:
```
Key pressed:  97-a  (a) modifiers: NUM
Key released:  97-a  modifiers: NUM
Unknown Key (scancode = 148) pressed  modifiers: NUM
Unknown Key (scancode = 148) released  modifiers: NUM
```

With this change, it now looks like:
```
Key pressed:  97-a (scancode = 38 [0x26]) (a) modifiers: NUM
Key released:  97-a (scancode = 38 [0x26]) modifiers: NUM
Unknown Key (scancode = 148 [0x94]) pressed  modifiers: NUM
Unknown Key (scancode = 148 [0x94]) released  modifiers: NUM
```