### PR TITLE
Hide symbols by default in the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(SDL12DEVEL "Enable installing SDL-1.2 development headers" ON)
 option(STATICDEVEL "Enable installing static link library" OFF)
 
 set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 if(APPLE)
   set(OSX_SRCS "src/SDL12_compat_objc.m")


### PR DESCRIPTION
... otherwise the drmp3 symbols are exported by libSDL-1.2.so.

Signed-off-by: Stephen Kitt <steve@sk2.org>