### PR TITLE
Close audio device in SDL_Quit{,Subsystem}()

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1710,6 +1710,10 @@ SDL_QuitSubSystem(Uint32 sdl12flags)
         QuitCDSubsystem();
     }
 
+    if (sdl12flags & SDL12_INIT_AUDIO) {
+        SDL_CloseAudio();
+    }
+
     if (sdl12flags & SDL12_INIT_VIDEO) {
         Quit12Video();
     }
@@ -6775,11 +6779,10 @@ SDL_CloseAudio(void)
     SDL20_LockAudio();
     if (audio_cbdata) {
         audio_cbdata->app_callback_opened = SDL_FALSE;
+        SDL20_FreeAudioStream(audio_cbdata->app_callback_stream);
+        audio_cbdata->app_callback_stream = NULL;
     }
     SDL20_UnlockAudio();
-
-    SDL20_FreeAudioStream(audio_cbdata->app_callback_stream);
-    audio_cbdata->app_callback_stream = NULL;
 
     CloseSDL2AudioDevice();
 }


### PR DESCRIPTION
Given we allocate and use a bunch of wrappers around the SDL audio device, we should shut it down explicitly on quit.

The simplest way to implement this was to just call our ``SDL_CloseAudio()`` implementation in ``SDL_QuitSubsystem()``, which require making it robust against closing an already closed audio device.

This fixes a sporadic null pointer access in the audio callback on DOSBox on one of my machines.