### PR TITLE
SDL_PauseAudio should work within the callback

### DIFF
--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -188,6 +188,9 @@ SDL20_SYM_PASSTHROUGH(int,CondBroadcast,(SDL_cond *a),(a),return)
 SDL20_SYM_PASSTHROUGH(int,CondWait,(SDL_cond *a, SDL_mutex *b),(a,b),return)
 SDL20_SYM_PASSTHROUGH(int,CondWaitTimeout,(SDL_cond *a, SDL_mutex *b, Uint32 c),(a,b,c),return)
 
+SDL20_SYM(int,AtomicGet,(SDL_atomic_t *a),(a),return)
+SDL20_SYM(void,AtomicSet,(SDL_atomic_t *a, int b),(a,b),)
+
 SDL20_SYM(SDL_AudioSpec *,LoadWAV_RW,(SDL_RWops *a, int b, SDL_AudioSpec *c, Uint8 **d, Uint32 *e),(a,b,c,d,e),return)
 SDL20_SYM(int,OpenAudio,(SDL_AudioSpec *a, SDL_AudioSpec *b),(a,b),return)
 SDL20_SYM(void,CloseAudio,(void),(),)


### PR DESCRIPTION
In SDL 1.2, ``SDL_PauseAudio()`` works from within the audio callback, whereas currently in sdl12-compat, it deadlocks due to ``SDL_LockAudio()`` being called.

Move the callback paused state out of the ``AudioCallbackWrapperData`` callback structure (whose allocation is protected by ``SDL_LockAudio()``) and into a separate atomic variable. ``SDL_PauseAudio()`` can then simply set that value.

This fixes some SDL 1.2 Ren'py games, which will deadlock somewhat randomly either at startup or when a new piece of music plays, due to ``SDL_PauseAudio()`` being called from within the callback.

There may be scope down the line for having sdl12-compat have a custom ``SDL_LockAudio()`` implementation which doesn't interfere with the CD audio playback, too, but even then ``SDL_PauseAudio()`` couldn't lock the callback without breaking this.