### PR TITLE
Mouse position should be consistant between events and GetMouseState in relative mode

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -3138,6 +3138,7 @@ EventFilter20to12(void *data, SDL_Event *event20)
                     } else if (MousePosition.axis >= VideoSurface12->dim) { \
                         MousePosition.axis = (VideoSurface12->dim - 1); \
                     } \
+                    event12.motion.axis = MousePosition.axis; \
                 }
                 ADJUST_RELATIVE(x, xrel, w);
                 ADJUST_RELATIVE(y, yrel, h);
@@ -3156,9 +3157,15 @@ EventFilter20to12(void *data, SDL_Event *event20)
                 event12.button.button += 2; /* SDL_BUTTON_X1/2 */
             }
             event12.button.state = event20->button.state;
-            AdjustOpenGLLogicalScalingPoint(&event20->button.x, &event20->button.y);
-            event12.button.x = (Uint16) event20->button.x;
-            event12.button.y = (Uint16) event20->button.y;
+            if (MouseInputIsRelative) {
+                /* If we're using relative mouse input, we need to use our "fake" position. */
+                event12.button.x = MousePosition.x;
+                event12.button.y = MousePosition.y;
+            } else {
+                AdjustOpenGLLogicalScalingPoint(&event20->button.x, &event20->button.y);
+                event12.button.x = (Uint16) event20->button.x;
+                event12.button.y = (Uint16) event20->button.y;
+            }
             break;
 
         case SDL_MOUSEBUTTONUP:
@@ -3169,9 +3176,15 @@ EventFilter20to12(void *data, SDL_Event *event20)
                 event12.button.button += 2; /* SDL_BUTTON_X1/2 */
             }
             event12.button.state = event20->button.state;
-            AdjustOpenGLLogicalScalingPoint(&event20->button.x, &event20->button.y);
-            event12.button.x = (Uint16) event20->button.x;
-            event12.button.y = (Uint16) event20->button.y;
+            if (MouseInputIsRelative) {
+                /* If we're using relative mouse input, we need to use our "fake" position. */
+                event12.button.x = MousePosition.x;
+                event12.button.y = MousePosition.y;
+            } else {
+                AdjustOpenGLLogicalScalingPoint(&event20->button.x, &event20->button.y);
+                event12.button.x = (Uint16) event20->button.x;
+                event12.button.y = (Uint16) event20->button.y;
+            }
             break;
 
         case SDL_MOUSEWHEEL:


### PR DESCRIPTION
When the mouse is in Relative Mode (MouseInputIsRelative is true), we
"fake" the mouse position by integrating the relative coordinates
(adding them to the MousePosition variable, which accumulates the
position over time).

However, only SDL_GetMouseState() would actually use these
coordinates, events still used the raw position from the system
(possibly scaled, as both the SDL_RenderSetLogicalSize() and OpenGL
based scaling only affects the position, not the relative values). This
creates a mismatch: mouse coordinates received from events don't match
those received from SDL_GetMouseState().

Instead, we should update the mouse coordinates of the SDL 1.2 events
produced to match what we're keeing in the MousePosition variable. We
also do this for mouse button events, as otherwise clicks would hit a
different target from the visible cursor if a software cursor is
rendered.

This is still not perfect: the real and fake mouse positions are
different, so toggling relative mode can result in a "jump" in the mouse
coordinates. Relative mouse movements are also not scaled, so the mouse
movement speed can be different in relative mode.

Tested this against Ren'py SDL 1.2's software mouse cursor option, and
verified no regressions in Wolf4SDL and Multiwinia.