### PR TITLE
Don't add the 2.0->1.2 event conversion filter twice

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1734,6 +1734,7 @@ Init12Video(void)
     SupportSysWM = SDL_FALSE;
 #endif
 
+    SDL20_DelEventWatch(EventFilter20to12, NULL);
     SDL20_AddEventWatch(EventFilter20to12, NULL);
 
     VideoDisplayIndex = GetVideoDisplay();


### PR DESCRIPTION
If the program creates several windows (such as Unreal Tournament 2004's
splash screen), the Event Filter used to convert SDL 2.0 events to SDL
1.2 events can end up being added twice, which causes events to be
converted twice).

Unconditionally remove the event filter in Init12Video() before
adding it, to ensure it only ever appears once. This fixes issue #119.