### PR TITLE
Add `-lmingw32` to `SDL_LIBS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(SDL12DEVEL)
     if(WIN32)
       set(SDL_CFLAGS "")
       set(SDL_RLD_FLAGS "")
-      set(SDL_LIBS "-lSDLmain -lSDL -mwindows")             # -lmingw32 -lSDL -mwindows
+      set(SDL_LIBS "-lmingw32 -lSDLmain -lSDL -mwindows")
       set(SDL_STATIC_LIBS "")
     elseif(APPLE)
       set(SDL_CFLAGS "-D_THREAD_SAFE")


### PR DESCRIPTION
This prevents undefined references to `WinMain@16` by consumers.

(From @manisandro for [the Fedora `mingw-sdl12-compat` package](https://src.fedoraproject.org/rpms/mingw-sdl12-compat/c/60d858f997a3f0ca137ff1dd2135c462cf0eda21?branch=rawhide))