### PR TITLE
Scale relative mouse coordinates when OpenGL Logical Scaling is in use

### DIFF
--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -308,11 +308,13 @@ SDL20_SYM(int,atoi,(const char *a),(a),return)
 #ifndef SDL12_MATH
 #include <math.h>
 #define SDL20_fabsf fabs
+#define SDL20_ceilf ceil
 #define SDL20_floorf floor
 #define SDL12_MATH
 #endif
 #else
 SDL20_SYM(float,fabsf,(float a),(a),return)
+SDL20_SYM(float,ceilf,(float a),(a),return)
 SDL20_SYM(float,floorf,(float a),(a),return)
 #endif
 


### PR DESCRIPTION
The SDL_Render-based logical scaling (using ``SDL_RenderSetLogicalSize()``) will scale both the relative and absolute mouse inputs, whereas we were only scaling the absolute mouse position. To match the SDL_Render mode, this change adds relative mouse motion scaling to the OpenGL Logical Scaling code, as well as the ability to disable it with the ``SDL_MOUSE_RELATIVE_SCALING`` environment variable (already supported by SDL_Render).

Note that the actual difference in behaviour here is extremely subtle, and hasn't been causing any actual issues as far as I can tell, but it could "feel" a little bit weird, particularly on games which were using relative mouse motion to control a cursor.

Most of these issues were fixed in SDL 2.0 as a result of this bug report:
https://github.com/libsdl-org/SDL/issues/3407

I think this is good to go, but the interaction with the ``SDL_MOUSE_RELATIVE_SCALING`` hint could be changed to either:
- Use the SDL 2.0 hint system entirely, and use ``SDL20_GetHintBoolean()`` instead of ``getenv()``.
- Drop the use of the hint for the SDL_Render backend as well, and wrap it in a new environment variable with a new name (and set ``SDL_HINT_MOUSE_RELATIVE_SCALING`` based on that).

(But personally, I think I prefer it like this…)