### PR TITLE
Do not generate VIDEORESIZE events on SIZE_CHANGED (fix #127)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -2991,8 +2991,11 @@ EventFilter20to12(void *data, SDL_Event *event20)
                     break;
 
                 case SDL_WINDOWEVENT_RESIZED:
-                case SDL_WINDOWEVENT_SIZE_CHANGED:
-                    FIXME("what's the difference between RESIZED and SIZE_CHANGED?");
+                    /* don't generate a VIDEORESIZE event based on SIZE_CHANGED
+                       events: the recommended way to handle VIDEORESIZE is
+                       with a new SDL_SetVideoMode() call, and creating a new
+                       window generates a SIZE_CHANGED event, which leads to an
+                       infinite loop. */
 
                     /* don't report VIDEORESIZE if we're fullscreen-desktop;
                        we're doing logical scaling and as far as the app is


### PR DESCRIPTION
The recommended way to handle ``VIDEORESIZE`` is with a new ``SDL_SetVideoMode()`` call, and creating a new window generates a ``SIZE_CHANGED`` event, which leads to an infinite loop. The other main case for ``SIZE_CHANGED`` events is when the screen resolution is changed out from underneath a fullscreen window, and we handle that with the logical scaling.

So it doesn't appear that there's any use for ``SIZE_CHANGED`` events in SDL 1.2 applications. So let's just ignore them. This fixes Drawf Fortress in bug #127.

The other possible fix is to check if a SIZE_CHANGED event has the same size as the current window anyway (and is therefore a no-op), and discard it if so. But there's no easy record of the previous resolution which exists across both OpenGL and non-OpenGL windows, so it didn't seem worth investigating at this point.