### PR TITLE
Don't recreate the window on resize, even in windowed mode

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -4324,8 +4324,6 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
         EndVidModeCreate();  /* rebuild the window if moving to/from a GL context */
     } else if (VideoSurface12 && (VideoSurface12->surface20->format->format != appfmt)) {
         EndVidModeCreate();  /* rebuild the window if changing pixel format */
-    } else if (VideoSurface12 && (VideoSurface12->w != width || VideoSurface12->h != height) && ((flags12 & SDL12_FULLSCREEN) == 0)) {
-        EndVidModeCreate(); /* rebuild the window if window size changed and not in full screen */
     } else if (VideoGLContext20) {
         /* SDL 1.2 (infuriatingly!) destroys the GL context on each resize, so we will too */
         SDL20_GL_MakeCurrent(NULL, NULL);


### PR DESCRIPTION
Resizable SDL 1.2 windows are really annoying to use when the window gets repeatedly recreated, as (at least on some window managers) this resets the resize operation.

This follows on from bug #127, as Dwarf Fortress hits this issue, being a resizable window which calls ``SDL_SetVideoMode()`` on every ``SDL_VIDEORESIZE`` event. With this change, resizing now seems to work identically to the SDL 1.2 version.

I'm not sure why we explicitly disabled this, though, so maybe there's a regression somewhere I don't know about. If so, maybe this is something we only do for ``SDL_RESIZABLE`` windows, or something?