### PR TITLE
Support SDL12COMPAT_SYNC_TO_VBLANK for OpenGL apps

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -4408,6 +4408,7 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
     }
 
     if (flags12 & SDL12_OPENGL) {
+        const char *vsync_env = SDL20_getenv("SDL12COMPAT_SYNC_TO_VBLANK");
         SDL_assert(!VideoTexture20);  /* either a new window or we destroyed all this */
         SDL_assert(!VideoRenderer20);
         FIXME("Should we force a compatibility context here?");
@@ -4456,7 +4457,11 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
             VideoSurface12->flags |= SDL12_OPENGLBLIT;
         }
 
-        SDL20_GL_SetSwapInterval(SwapInterval);
+        if (vsync_env) {
+            SDL20_GL_SetSwapInterval(SDL20_atoi(vsync_env));
+        } else {
+            SDL20_GL_SetSwapInterval(SwapInterval);
+        }
 
     } else {
         /* always use a renderer for non-OpenGL windows. */
@@ -5728,7 +5733,6 @@ SDL_GL_SetAttribute(SDL12_GLattr attr, int value)
     /* swap control was moved out of this API, everything else lines up. */
     if (attr == SDL12_GL_SWAP_CONTROL) {
         SwapInterval = value;
-        FIXME("Actually set swap interval somewhere");
         return 0;
     }
     else if (attr == SDL12_GL_MULTISAMPLESAMPLES) {


### PR DESCRIPTION
For non-OpenGL applications, the ``SDL12COMPAT_SYNC_TO_VBLANK`` environment variable could be used to enable/disable VSync. For OpenGL applications, this was always able to be controlled by the application, using the ``SDL_GL_SWAP_CONTROL`` attribute. However, some old games do not provide a simple mechanism for configuring VSync (and so either don't set ``SDL_GL_SWAP_CONTROL``, or always set it to an undesirable value).

Allow the ``SDL12COMPAT_SYNC_TO_VBLANK`` environment variable to override the ``SDL_GL_SWAP_CONTROL`` attribute for OpenGL windows. The existing behaviour remains if ``SDL12COMPAT_SYNC_TO_VBLANK`` is not set.

(Also remove a FIXME() which was obsolete.)