### PR TITLE
checkkeys test: Improve printing of Unicode-Chars

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -2654,7 +2654,7 @@ Keysym20to12(const SDL_Keycode keysym20)
     CASEKEYSYM20TO12(LALT);
     CASEKEYSYM20TO12(MODE);
     CASEKEYSYM20TO12(HELP);
-    CASEKEYSYM20TO12(SYSREQ);;
+    CASEKEYSYM20TO12(SYSREQ);
     CASEKEYSYM20TO12(MENU);
     CASEKEYSYM20TO12(POWER);
     CASEKEYSYM20TO12(UNDO);
@@ -2671,7 +2671,7 @@ Keysym20to12(const SDL_Keycode keysym20)
      * So I'm using that as a reference for our mappings, which only use
      * the lowest byte of the XK_* value, because of X11_KeySym & 0xFF in SDL1.2
      *
-     * case UTC4_code: return (SDL12Key)lowest_byte_of_corresponding_X11_KeySym; */
+     * case UCS4_code: return (SDL12Key)lowest_byte_of_corresponding_X11_KeySym; */
 
     /* Latin-2 */
     case 0x0104: return (SDL12Key)0xa1;

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -68,13 +68,19 @@ static void PrintKey(SDL_keysym *sym, int pressed)
 			printf(" (^%c)", sym->unicode+'@');
 		} else {
 #ifdef UNICODE
-			printf(" (%c)", sym->unicode);
-#else
+			printf(" '%c' (0x%.4X)", sym->unicode, (int)sym->unicode);
+#elif defined(_WIN32)
 			/* This is a Latin-1 program, so only show 8-bits */
 			if ( !(sym->unicode & 0xFF00) )
-				printf(" (%c)", sym->unicode);
+				printf(" '%c' (0x%.4X)", sym->unicode, (int)sym->unicode);
 			else
-				printf(" (0x%X)", sym->unicode);
+				printf(" (0x%.4X)", (int)sym->unicode);
+#else /* other platforms than Windows hopefully use UTF-8 for 8bit chars */
+			Uint32 utf32str[2] = { sym->unicode, 0 };
+			const char* utf32type = (SDL_BYTEORDER == SDL_LIL_ENDIAN) ? "UTF-32LE" : "UTF-32BE";
+			char* utf8str = SDL_iconv_string("UTF-8", utf32type, (const char*)utf32str, 2*4);
+			printf(" '%s' (0x%.4X)", utf8str, (int)sym->unicode);
+			SDL_free(utf8str);
 #endif
 		}
 	}


### PR DESCRIPTION
.. at least on platforms that use UTF-8, like modern Linux (Windows should work as well as before).

Also unified the output to print sth like "'Ä' (0x00C4)", i.e. both the actual char and the unicode constant, on all platforms.

Before these changes, on Linux it would print garbage or nothing for the unicode character, if it wasn't from the ASCII range