### PR TITLE
Bunch of FIXME-related fixes

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -923,6 +923,7 @@ static char *WindowTitle = NULL;
 static char *WindowIconTitle = NULL;
 static SDL_Surface *VideoIcon20 = NULL;
 static int EnabledUnicode = 0;
+static SDL_bool EnabledKeyRepeat = SDL_TRUE;
 /* Windows SDL1.2 never uses translated keyboard layouts for compatibility with
 DirectInput, which didn't support them. Other platforms (MacOS, Linux) seem to,
 but with varying levels of bugginess. So default to Translated Layouts on
@@ -3785,7 +3786,7 @@ EventFilter20to12(void *data, SDL_Event *event20)
 
         case SDL_KEYDOWN:
             FlushPendingKeydownEvent(0);
-            if (event20->key.repeat) {
+            if (event20->key.repeat && !EnabledKeyRepeat) {
                 return 1;  /* ignore 2.0-style key repeat events */
             }
 
@@ -6569,21 +6570,22 @@ SDL_GetGammaRamp(Uint16 *red, Uint16 *green, Uint16 *blue)
 DECLSPEC int SDLCALL
 SDL_EnableKeyRepeat(int delay, int interval)
 {
-    FIXME("write me");
-    (void) delay;
+    FIXME("Support non-default delay and interval for Key Repeat");
     (void) interval;
+
+    EnabledKeyRepeat = (delay != 0) ? SDL_TRUE : SDL_FALSE;
+
     return 0;
 }
 
 DECLSPEC void SDLCALL
 SDL_GetKeyRepeat(int *delay, int *interval)
 {
-    FIXME("write me");
     if (delay) {
-        *delay = SDL12_DEFAULT_REPEAT_DELAY;
+        *delay = EnabledKeyRepeat ? SDL12_DEFAULT_REPEAT_DELAY : 0;
     }
     if (interval) {
-        *interval = SDL12_DEFAULT_REPEAT_INTERVAL;
+        *interval = EnabledKeyRepeat ? SDL12_DEFAULT_REPEAT_INTERVAL : 0;
     }
 }
 

--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1569,6 +1569,12 @@ GetVideoDisplay(void)
         variable = SDL20_getenv("SDL_VIDEO_FULLSCREEN_HEAD");
     }
     if (variable) {
+        int preferred_display = SDL20_atoi(variable);
+        
+        if (preferred_display < 0 || preferred_display >= SDL20_GetNumVideoDisplays()) {
+            return 0;
+        }
+
         return SDL20_atoi(variable);
     } else {
         return 0;
@@ -4579,6 +4585,9 @@ GetEnvironmentWindowPosition(int *x, int *y)
     if (center) {
         *x = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
         *y = SDL_WINDOWPOS_CENTERED_DISPLAY(display);
+    } else {
+        *x = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
+        *y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
     }
 }
 
@@ -4969,8 +4978,7 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
         return NULL;
     }
 
-    FIXME("There's an environment variable to choose a display");
-    if (SDL20_GetCurrentDisplayMode(0, &dmode) < 0) {
+    if (SDL20_GetCurrentDisplayMode(VideoDisplayIndex, &dmode) < 0) {
         return NULL;
     }
 

--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -4886,7 +4886,7 @@ InitializeOpenGLScaling(const int w, const int h)
         OpenGLFuncs.glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, OpenGLLogicalScalingMultisampleColor);
         OpenGLFuncs.glGenRenderbuffers(1, &OpenGLLogicalScalingMultisampleDepth);
         OpenGLFuncs.glBindRenderbuffer(GL_RENDERBUFFER, OpenGLLogicalScalingMultisampleDepth);
-        OpenGLFuncs.glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, w, h);  FIXME("is an extension (or core 3.0)?");
+        OpenGLFuncs.glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, w, h);
         OpenGLFuncs.glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, OpenGLLogicalScalingMultisampleDepth);
         OpenGLFuncs.glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, OpenGLLogicalScalingMultisampleDepth);
         OpenGLFuncs.glBindRenderbuffer(GL_RENDERBUFFER, 0);

--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -79,6 +79,7 @@ SDL20_SYM(int,GetNumDisplayModes,(int a),(a),return)
 SDL20_SYM(int,GetDisplayMode,(int a, int b, SDL_DisplayMode *c),(a,b,c),return)
 SDL20_SYM(int,GetDesktopDisplayMode,(int a, SDL_DisplayMode *b),(a,b),return)
 SDL20_SYM(int,GetCurrentDisplayMode,(int a, SDL_DisplayMode *b),(a,b),return)
+SDL20_SYM(int,GetWindowDisplayMode,(SDL_Window *a, SDL_DisplayMode *b),(a,b),return)
 
 SDL20_SYM(void,EnableScreenSaver,(void),(),)
 SDL20_SYM(void,DisableScreenSaver,(void),(),)

--- a/src/SDL20_syms.h
+++ b/src/SDL20_syms.h
@@ -74,6 +74,7 @@ SDL20_SYM(Uint8,EventState,(Uint32 a, int b),(a,b),return)
 
 SDL20_SYM(SDL_bool,GetWindowWMInfo,(SDL_Window *a, SDL_SysWMinfo *b),(a,b),)
 
+SDL20_SYM(int,GetNumVideoDisplays,(void),(),return)
 SDL20_SYM(int,GetNumDisplayModes,(int a),(a),return)
 SDL20_SYM(int,GetDisplayMode,(int a, int b, SDL_DisplayMode *c),(a,b,c),return)
 SDL20_SYM(int,GetDesktopDisplayMode,(int a, SDL_DisplayMode *b),(a,b),return)


### PR DESCRIPTION
[I'm happy to split one or all of these out into separate PRs if some are more controversial than others.]

This is a bunch of changes related to various FIXMEs in the sdl12-compat code, as noted in #143. This change includes:

- ``glRenderbufferStorate()`` is a part of core GL 3, so get rid of the fixme reminding us to check.
- ``SDL_VIDEO_FULLSCREEN_DISPLAY`` was only partly supported, complete it.
- Make the timing of presentations in UpdateRects and when handling YUV overlays refresh-rate dependent.
- Add a very basic ``SDL_EnableKeyRepeat()`` implementation which ignores the delay/interval and just uses SDL2's repeat field.

(Largely in order from least to most controversial.) The only real issues I can imagine are:
- The ``GetEnvironmentWindowPosition()`` function now sets x and y unconditionally, so intialising them to ``SDL_WINDOWPOS_UNDEFINED`` in ``SDL_SetVideoMode()`` is now useless.
- ``GetDesiredMillisecondsPerFrame()`` could be more accurate in windowed-mode if the window is dragged between different screens.
- ``GetDesiredMillisecondsPerFrame()`` has (obviously) millisecond resolution, so will not be able to accurately represent, e.g, 60Hz displays. (But it's better than the hardcoded 15).
- ``SDL_EnableKeyRepeat()`` doesn't support the ``delay``/``interval`` parameters properly. Even when key repeats are disabled, we still get KEYDOWN events via the SDL2 TEXTINPUT events (though this existed prior to this change).