### PR TITLE
Macos deprecation fixes

### DIFF
--- a/src/SDLmain/macosx/SDLMain.h
+++ b/src/SDLmain/macosx/SDLMain.h
@@ -19,13 +19,13 @@
 /* Use this flag to determine whether we use CPS (docking) or not */
 #define		SDL_USE_CPS		1
 
-@interface SDLMain : NSApplicationDelegate
+@interface SDLMain : NSObject<NSApplicationDelegate>
 - (NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication *)sender;
 - (void) setupWorkingDirectory:(BOOL)shouldChdir;
-- (BOOL) application:(NSApplication *)theApplication openFile:(NSString *)filename
-- (void) applicationDidFinishLaunching: (NSNotification *) note
+- (BOOL) application:(NSApplication *)theApplication openFile:(NSString *)filename;
+- (void) applicationDidFinishLaunching: (NSNotification *) note;
 #if SDL_USE_NIB_FILE
-- (void)fixMenu:(NSMenu *)aMenu withAppName:(NSString *)appName
+- (void)fixMenu:(NSMenu *)aMenu withAppName:(NSString *)appName;
 #endif
 @end
 

--- a/src/SDLmain/macosx/SDLMain.h
+++ b/src/SDLmain/macosx/SDLMain.h
@@ -16,9 +16,6 @@
 /* Use this flag to determine whether we use SDLMain.nib or not */
 #define		SDL_USE_NIB_FILE	0
 
-/* Use this flag to determine whether we use CPS (docking) or not */
-#define		SDL_USE_CPS		1
-
 @interface SDLMain : NSObject<NSApplicationDelegate>
 - (NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication *)sender;
 - (void) setupWorkingDirectory:(BOOL)shouldChdir;

--- a/src/SDLmain/macosx/SDLMain.h
+++ b/src/SDLmain/macosx/SDLMain.h
@@ -10,7 +10,23 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface SDLMain : NSObject
+/* Note that the following defines have not been changed in a long time and
+   it's likely going to need fixes if you try it. */
+
+/* Use this flag to determine whether we use SDLMain.nib or not */
+#define		SDL_USE_NIB_FILE	0
+
+/* Use this flag to determine whether we use CPS (docking) or not */
+#define		SDL_USE_CPS		1
+
+@interface SDLMain : NSApplicationDelegate
+- (NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication *)sender;
+- (void) setupWorkingDirectory:(BOOL)shouldChdir;
+- (BOOL) application:(NSApplication *)theApplication openFile:(NSString *)filename
+- (void) applicationDidFinishLaunching: (NSNotification *) note
+#if SDL_USE_NIB_FILE
+- (void)fixMenu:(NSMenu *)aMenu withAppName:(NSString *)appName
+#endif
 @end
 
 #endif /* _SDLMain_h_ */

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -64,22 +64,17 @@ static NSString *getApplicationName(void)
 @end
 #endif
 
-@interface NSApplication (SDLApplication)
-@end
+/* The main class of the application, the application's delegate */
+@implementation SDLMain
 
-@implementation NSApplication (SDLApplication)
-/* Invoked from the Quit menu item */
-- (void)terminate:(id)sender
+- (NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication *)sender
 {
     /* Post a SDL_QUIT event */
     SDL_Event event;
     event.type = SDL_QUIT;
     SDL_PushEvent(&event);
+    return NSTerminateCancel;
 }
-@end
-
-/* The main class of the application, the application's delegate */
-@implementation SDLMain
 
 /* Set the working directory to the .app's parent directory */
 - (void) setupWorkingDirectory:(BOOL)shouldChdir

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -17,6 +17,9 @@
 - (void)setAppleMenu:(NSMenu *)menu;
 @end
 
+/* NSEventModifierFlagOption replaced NSAlternateKeyMask in 10.12, but it's the same value. */
+#define EventModifierFlagOption (1 << 19)
+
 /* Use this flag to determine whether we use SDLMain.nib or not */
 #define		SDL_USE_NIB_FILE	0
 
@@ -139,7 +142,7 @@ static void setApplicationMenu(void)
     [appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
 
     menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
-    [menuItem setKeyEquivalentModifierMask:(NSAlternateKeyMask|NSCommandKeyMask)];
+    [menuItem setKeyEquivalentModifierMask:(EventModifierFlagOption|NSCommandKeyMask)];
 
     [appleMenu addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
 

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -262,14 +262,6 @@ static void CustomApplicationMain (int argc, char **argv)
 {
     int status;
 
-    /* Get more aggressive about activation for Catalina and later: activate the Dock first so we definitely reset all activation state. */
-    for (NSRunningApplication *i in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.dock"]) {
-        [i activateWithOptions:NSApplicationActivateIgnoringOtherApps];
-        break;
-    }
-    SDL_Delay(300);  /* !!! FIXME: this isn't right. */
-    [NSApp activateIgnoringOtherApps:YES];
-
     /* Set the working directory to the .app's parent directory */
     [self setupWorkingDirectory:gFinderLaunch];
 

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -19,6 +19,8 @@
 
 /* NSEventModifierFlagOption replaced NSAlternateKeyMask in 10.12, but it's the same value. */
 #define EventModifierFlagOption (1 << 19)
+/* Same deal with the NSCommandKeyMask... */
+#define EventModifierFlagCommand (1 << 20)
 
 /* Use this flag to determine whether we use SDLMain.nib or not */
 #define		SDL_USE_NIB_FILE	0
@@ -142,7 +144,7 @@ static void setApplicationMenu(void)
     [appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
 
     menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
-    [menuItem setKeyEquivalentModifierMask:(EventModifierFlagOption|NSCommandKeyMask)];
+    [menuItem setKeyEquivalentModifierMask:(EventModifierFlagOption|EventModifierFlagCommand)];
 
     [appleMenu addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
 

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -186,6 +186,9 @@ static void CustomApplicationMain (int argc, char **argv)
     ProcessSerialNumber psn = { 0, kCurrentProcess};
     TransformProcessType(&psn, kProcessTransformToForegroundApplication);
 
+    /* Ensure the application object is initialised */
+    [NSApplication sharedApplication];
+
     /* Set up the menubar */
     [NSApp setMainMenu:[[NSMenu alloc] init]];
     setApplicationMenu();

--- a/src/SDLmain/macosx/SDLMain.m
+++ b/src/SDLmain/macosx/SDLMain.m
@@ -22,11 +22,6 @@
 /* Same deal with the NSCommandKeyMask... */
 #define EventModifierFlagCommand (1 << 20)
 
-/* Use this flag to determine whether we use SDLMain.nib or not */
-#define		SDL_USE_NIB_FILE	0
-
-/* Use this flag to determine whether we use CPS (docking) or not */
-#define		SDL_USE_CPS		1
 #ifdef SDL_USE_CPS
 /* Portions of CPS.h */
 typedef struct CPSProcessSerNum


### PR DESCRIPTION
These clean up deprecation warnings, etc, in macos's SDLmain code.

Fixes #106. (at least, it fixes the last remaining items on that issue.)