### PR TITLE
cmake: Rewire and simplify project versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,8 @@
 
 cmake_minimum_required(VERSION 3.0.0)
 project(sdl12_compat
-        VERSION 0.0.1
+        VERSION 1.2.50
         LANGUAGES C)
-
-set(SDL12_COMPAT_VERSION_STR "1.2.50")
 
 option(SDL12TESTS "Enable to build SDL-1.2 test programs" ON)
 option(SDL12DEVEL "Enable installing SDL-1.2 development headers" ON)
@@ -86,7 +84,7 @@ if(APPLE)
     )
 elseif(UNIX AND NOT ANDROID)
     set_target_properties(SDL PROPERTIES
-        VERSION "${SDL12_COMPAT_VERSION_STR}"
+        VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
         OUTPUT_NAME "SDL-1.2")
 elseif(WIN32)
@@ -94,18 +92,18 @@ elseif(WIN32)
     set(CMAKE_SHARED_LIBRARY_PREFIX "")
     set_target_properties(SDL PROPERTIES COMPILE_DEFINITIONS "DLL_EXPORT")
     set_target_properties(SDL PROPERTIES
-        VERSION "${SDL12_COMPAT_VERSION_STR}"
+        VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
       OUTPUT_NAME "SDL")
 elseif(OS2)
     set_target_properties(SDL PROPERTIES COMPILE_DEFINITIONS "BUILD_SDL") # for DECLSPEC
     set_target_properties(SDL PROPERTIES
-        VERSION "${SDL12_COMPAT_VERSION_STR}"
+        VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
         OUTPUT_NAME "SDL12")
 else()
     set_target_properties(SDL PROPERTIES
-        VERSION "${SDL12_COMPAT_VERSION_STR}"
+        VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
       OUTPUT_NAME "SDL")
 endif()
@@ -239,8 +237,6 @@ install(TARGETS SDL SDLmain
 )
 
 if(SDL12DEVEL)
-  set(SDL_VERSION "${SDL12_COMPAT_VERSION_STR}")
-
   install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
   if(NOT MSVC)
@@ -303,7 +299,7 @@ if(STATICDEVEL AND SDL12DEVEL)
   set_target_properties(SDL-static PROPERTIES COMPILE_DEFINITIONS "_REENTRANT")
   target_link_libraries(SDL-static PRIVATE dl)
   set_target_properties(SDL-static PROPERTIES
-          VERSION "${SDL12_COMPAT_VERSION_STR}"
+          VERSION "${PROJECT_VERSION}"
         OUTPUT_NAME "SDL")
 
   install(TARGETS SDL-static

--- a/sdl-config.in
+++ b/sdl-config.in
@@ -47,7 +47,7 @@ while test $# -gt 0; do
       echo $exec_prefix
       ;;
     --version)
-      echo @SDL_VERSION@
+      echo @PROJECT_VERSION@
       ;;
     --cflags)
       echo -I${includedir}/SDL @SDL_CFLAGS@

--- a/sdl12_compat.pc.in
+++ b/sdl12_compat.pc.in
@@ -8,7 +8,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: sdl12_compat
 Description: An SDL-1.2 compatibility layer that uses SDL 2.0 behind the scenes.
 Version: @PROJECT_VERSION@
-Provides: sdl = @SDL_VERSION@
+Provides: sdl = @PROJECT_VERSION@
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@
 @ENABLE_STATIC_TRUE@Libs.private: -L${libdir} @SDL_LIBS@ @SDL_STATIC_LIBS@
 Cflags: -I${includedir}/SDL @SDL_CFLAGS@


### PR DESCRIPTION
As we've decided that the emulated SDL version will be the project
version for sdl12-compat, unify and simplify the versioning constructs
throughout the project so we only have to deal with versioning in
one place.