### PR TITLE
Set 'pixels' in SDL_CreateYUVOverlay() (Fix #164)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -6337,6 +6337,10 @@ SDL_CreateYUVOverlay(int w, int h, Uint32 format12, SDL12_Surface *display12)
     retval->hw_overlay = 1;
     retval->pitches = hwdata->pitches;
 
+    /* Some programs (e.g. mplayer) access pixels without locking. */
+    retval->pixels = hwdata->pixels;
+    hwdata->dirty = SDL_TRUE;
+
     return retval;
 }
 


### PR DESCRIPTION
Some applications, such as mplayer with ``-vo sdl`` will access the ``pixels`` member of an ``SDL_Overlay`` immediately after creating it, without ever locking it. This works on (at least some backends for) SDL 1.2, but crashed on sdl12-compat, as pixels remained unset until ``SDL_LockYUVOverlay()`` is called.

Set ``pixels`` in ``SDL_CreateYUVOverlay()``, as well as ``hwdata->dirty``, which
makes it possible to have a working YUV overlay without ever locking/unlocking it. This is required for mplayer's sdl vo backend to function.

Fixes issue #164.