### PR TITLE
Update SDL12_COMPAT_VERSION to 53 for 1.2.53

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -28,7 +28,7 @@
  *  should be way ahead of what SDL-1.2 Classic would report, so apps can
  *  decide if they're running under the compat layer, if they really care.
  */
-#define SDL12_COMPAT_VERSION 50
+#define SDL12_COMPAT_VERSION 53
 
 #include <stdarg.h>
 #include <limits.h>


### PR DESCRIPTION
(Whoops, we forgot to update this for 1.2.52. :/)

This is used by SDL_Linked_Version().

Maybe it'd make sense to inject this from the build system, which should
already know what the version is. In the meantime, however, report
1.2.53.