### PR TITLE
Implement an application-compatibility "quirks" system (and hacky workaround for Awesomenauts)

### DIFF
--- a/src/SDL20_include_wrapper.h
+++ b/src/SDL20_include_wrapper.h
@@ -110,6 +110,7 @@
 #endif
 #ifdef __OS2__
 #define INCL_DOSMODULEMGR /* for Dos_LoadModule() & co. */
+#define INCL_DOSPROCESS
 #endif
 
 #define __BUILDING_SDL12_COMPAT__ 1


### PR DESCRIPTION
This follows the discussion in #168 and introduces a "quirks" table which allows application-specific workarounds to be implemented.

Basically, it works by adding an ``SDL12Compat_GetHint()`` function to replace the various ``getenv`` calls around the place, and makes that check an array of (executable name, hint name, hint value) tuples.

The list of quirks is platform-specific, and keyed on the executable filename (hence there being duplicates for different architectures).

I've also added a workaround for the Awesomenauts issue in bug #168, though it's a bit hacky.

I've also not added, e.g., Dynamite Jack, whose executable name is — I think — just "main". Things like driconf and vkd3d-proton's system support fancier ways of selecting these (with wildcards, or executable hashes, etc), but this should do for now.

There's a bunch of optimisation options still left on the table (places where we could cache things, or enforce the table being in alphabetical order to break out sooner, etc), and a bit of other ugliness, but it should work well enough for now. Please add entries as you find them!

Thanks to @sezero for the OS/2 implementation of ``GetExeName``. (I hope it works. :-))