### PR TITLE
Resolve relative paths when initialising CD audio

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -7455,7 +7455,17 @@ InitializeCDSubsystem(void)
 
     cdpath = SDL12Compat_GetHint("SDL12COMPAT_FAKE_CDROM_PATH");
     if (cdpath) {
+        char abspath[SDL12_MAXPATH];
+        /* Some games chdir() after initialising, making relative paths break. */
+#ifdef WIN32
+        /* There is a _fullpath() function, but it needs libc, which we don't use on Win32. */
+        GetFullPathNameA(cdpath, SDL12_MAXPATH, abspath, NULL);
+        CDRomPath = SDL_strdup(abspath);
+#elif defined(__unix__)
+        CDRomPath = SDL_strdup(realpath(cdpath, abspath));
+#else
         CDRomPath = SDL_strdup(cdpath);
+#endif
     }
 
     CDRomInit = SDL_TRUE;


### PR DESCRIPTION
Some games will ``chdir()`` in between initialising SDL and trying to play CD audio, which will break if the path passed to ``SDL12COMPAT_FAKE_CDROM_PATH`` is relative. Instead, resolve the relative path to an absolute path in ``InitializeCDSubsystem()``. It's still going to be a pain for the user if the game calls ``chdir()`` before even SDL is initialised, but it's better than nothing.

Implemented for (and tested on) Win32 and unix. Anything with ``realpath()`` should work.

One game which triggers this is the old Loki port of Civilization: Call to Power (which is technically SDL 1.1, admittedly).