### PR TITLE
quirk: Disable SDL_QuitSubsystem(SDL_INIT_VIDEO) for Multiwinia/steam

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1162,7 +1162,10 @@ static QuirkEntryType quirks[] = {
     /* GOG's DOSBox builds have architecture-specific filenames. */
     {"dosbox", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"},
     {"dosbox_i686", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"},
-    {"dosbox_x86_64", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"}
+    {"dosbox_x86_64", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"},
+
+    /* The 32-bit Steam build only of Multiwinia Quits but doesn't re-Init */
+    {"multiwinia.bin.x86", "SDL12COMPAT_NO_QUIT_VIDEO", "1"}
 #else
     /* TODO: Add any quirks needed for this system. */
 
@@ -2119,6 +2122,14 @@ DECLSPEC void SDLCALL
 SDL_QuitSubSystem(Uint32 sdl12flags)
 {
     Uint32 sdl20flags, extraflags;
+
+    /* Some games (notably the Steam build of Multiwinia), will
+     * SDL_Quit(SDL_INIT_VIDEO) on resolution change, and never call
+     * SDL_Init() again before creating their new window.
+     */
+    if (SDL12Compat_GetHintBoolean("SDL12COMPAT_NO_QUIT_VIDEO", SDL_FALSE)) {
+        sdl12flags &= ~SDL12_INIT_VIDEO;
+    }
     InitFlags12to20(sdl12flags, &sdl20flags, &extraflags);
 
     if (extraflags & SDL12_INIT_CDROM) {


### PR DESCRIPTION
For some reason, the Steam build of Multiwinia seems to be missing a call to ``SDL_Init()`` where the (older) non-Steam builds have one. This results in the game, when a resolution change is requested:
- Calling ``SDL_QuitSubsystem(SDL_INIT_VIDEO)`` when the old window is
  destroyed.
- **NOT** calling ``SDL_Init(SDL_INIT_VIDEO)`` when creating the new window (unlike the non-Steam builds).
- Calling ``SDL_GetVideoInfo()``, and promptly asserting when NULL is
  returned.
- (And then proceed to create a window, which will fail, etc…)

This issue _is_ reproducable under real SDL 1.2 (though with
SDL_VIDEO_FULLSCREEN_HEAD set, no other modes are listed, so it's
difficult to trigger), but it seemed worth working around.

To do so, simply make ``SDL_QuitSubsystem()`` mask out ``SDL_INIT_VIDEO``. This
is hidden behind a new ``SDL12COMPAT_NO_QUIT_VIDEO`` hint, which is enabled
by a quirk for "multiwinia.bin.x86".

The various non-steam builds of the game do have the appropriate call to ``SDL_Init()``, and the Steam build is 32-bit only, so we only activate this hack for the 32-bit builds. (Similarly, the old source dump I have has the ``SDL_Init()`` call in it, so who knows where it went…)

Steam App ID: [1530](https://steamdb.info/app/1530/)
Steam Build ID: [4497829](https://steamdb.info/patchnotes/4497829/)