### PR TITLE
Use SDL_PIXELFORMAT_RGB888 for 24-bit surfaces

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -5231,7 +5231,7 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags12)
     switch (bpp) {
         case  8: appfmt = SDL_PIXELFORMAT_INDEX8; break;
         case 16: appfmt = SDL_PIXELFORMAT_RGB565; FIXME("bgr instead of rgb?"); break;
-        case 24: appfmt = SDL_PIXELFORMAT_RGB24; FIXME("bgr instead of rgb?"); break;
+        case 24: appfmt = SDL_PIXELFORMAT_RGB888; FIXME("bgr instead of rgb?"); break;
         case 32: appfmt = SDL_PIXELFORMAT_XRGB8888; FIXME("bgr instead of rgb?"); break;
         default: SDL20_SetError("Unsupported bits-per-pixel"); return NULL;
     }


### PR DESCRIPTION
We're currently using SDL_PIXELFORMAT_RGB24, which results in
schismtracker being blue when resized (#183).

While it's possible that RGB888 is wrong on big-endian systems, it at
least matches what we do for 16-bit (RGB565) and 32-bit (XRGB8888)
formats, so if we're wrong, we'll at least be consistently wrong.