### PR TITLE
Check that HAVE_* macros are true, not just defined

### DIFF
--- a/include/SDL/SDL_stdinc.h
+++ b/include/SDL/SDL_stdinc.h
@@ -77,43 +77,43 @@ typedef enum SDL_DUMMY_ENUM
 
 SDL_COMPILE_TIME_ASSERT(enum, sizeof(SDL_DUMMY_ENUM) == sizeof(int));
 
-#ifdef HAVE_SYS_TYPES_H
+#if HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef HAVE_STDIO_H
+#if HAVE_STDIO_H
 #include <stdio.h>
 #endif
-#ifdef HAVE_STDLIB_H
+#if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#ifdef HAVE_MALLOC_H
+#if HAVE_MALLOC_H
 #include <malloc.h>
 #endif
-#ifdef HAVE_STDDEF_H
+#if HAVE_STDDEF_H
 #include <stddef.h>
 #endif
-#ifdef HAVE_STDARG_H
+#if HAVE_STDARG_H
 #include <stdarg.h>
 #endif
-#ifdef HAVE_STRING_H
+#if HAVE_STRING_H
 #include <string.h>
 #endif
-#ifdef HAVE_STRINGS_H
+#if HAVE_STRINGS_H
 #include <strings.h>
 #endif
-#ifdef HAVE_INTTYPES_H
+#if HAVE_INTTYPES_H
 #include <inttypes.h>
 #endif
-#ifdef HAVE_STDINT_H
+#if HAVE_STDINT_H
 #include <stdint.h>
 #endif
-#ifdef HAVE_CTYPE_H
+#if HAVE_CTYPE_H
 #include <ctype.h>
 #endif
-#ifdef HAVE_ICONV_H
+#if HAVE_ICONV_H
 #include <iconv.h>
 #endif
-#ifdef HAVE_ALLOCA_H
+#if HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
 
@@ -123,7 +123,7 @@ SDL_COMPILE_TIME_ASSERT(enum, sizeof(SDL_DUMMY_ENUM) == sizeof(int));
 not, so we try to #define them to be the C runtime equivalents as possible,
 so things built with these headers will still run against the real SDL 1.2. */
 
-#ifdef HAVE_ICONV
+#if HAVE_ICONV
 #define SDL_iconv_t iconv_t
 #define SDL_iconv_open iconv_open
 #define SDL_iconv_close iconv_close
@@ -135,231 +135,231 @@ extern DECLSPEC int SDLCALL SDL_iconv_close(SDL_iconv_t cd);
 extern DECLSPEC size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft);
 extern DECLSPEC char * SDLCALL SDL_iconv_string(const char *tocode, const char *fromcode, const char *inbuf, size_t inbytesleft);
 
-#ifdef HAVE_MALLOC
+#if HAVE_MALLOC
 #define SDL_malloc malloc
 #else
 extern DECLSPEC void * SDLCALL SDL_malloc(size_t size);
 #endif
 
-#ifdef HAVE_CALLOC
+#if HAVE_CALLOC
 #define SDL_calloc calloc
 #else
 extern DECLSPEC void * SDLCALL SDL_calloc(size_t nmemb, size_t size);
 #endif
 
-#ifdef HAVE_REALLOC
+#if HAVE_REALLOC
 #define SDL_realloc realloc
 #else
 extern DECLSPEC void * SDLCALL SDL_realloc(void *mem, size_t size);
 #endif
 
-#ifdef HAVE_FREE
+#if HAVE_FREE
 #define SDL_free free
 #else
 extern DECLSPEC void SDLCALL SDL_free(void *mem);
 #endif
 
-#ifdef HAVE_GETENV
+#if HAVE_GETENV
 #define SDL_getenv getenv
 #else
 extern DECLSPEC char * SDLCALL SDL_getenv(const char *name);
 #endif
 
-#ifdef HAVE_PUTENV
+#if HAVE_PUTENV
 #define SDL_putenv putenv
 #else
 extern DECLSPEC int SDLCALL SDL_putenv(const char *variable);
 #endif
 
-#ifdef HAVE_QSORT
+#if HAVE_QSORT
 #define SDL_qsort qsort
 #else
 extern DECLSPEC void SDLCALL SDL_qsort(void *base, size_t nmemb, size_t size, int (*compare)(const void *, const void *));
 #endif
 
-#ifdef HAVE_MEMSET
+#if HAVE_MEMSET
 #define SDL_memset memset
 #else
 extern DECLSPEC void * SDLCALL SDL_memset(void *dst, int c, size_t len);
 #endif
 
-#ifdef HAVE_MEMCPY
+#if HAVE_MEMCPY
 #define SDL_memcpy memcpy
 #else
 extern DECLSPEC void * SDLCALL SDL_memcpy(void *dst, const void *src, size_t len);
 #endif
 
-#ifdef HAVE_REVCPY
+#if HAVE_REVCPY
 #define SDL_revcpy revcpy
 #else
 extern DECLSPEC void * SDLCALL SDL_revcpy(void *dst, const void *src, size_t len);
 #endif
 
-#ifdef HAVE_MEMCMP
+#if HAVE_MEMCMP
 #define SDL_memcmp memcmp
 #else
 extern DECLSPEC int SDLCALL SDL_memcmp(const void *s1, const void *s2, size_t len);
 #endif
 
-#ifdef HAVE_STRLEN
+#if HAVE_STRLEN
 #define SDL_strlen strlen
 #else
 extern DECLSPEC size_t SDLCALL SDL_strlen(const char *string);
 #endif
 
-#ifdef HAVE_STRLCPY
+#if HAVE_STRLCPY
 #define SDL_strlcpy strlcpy
 #else
 extern DECLSPEC size_t SDLCALL SDL_strlcpy(char *dst, const char *src, size_t maxlen);
 #endif
 
-#ifdef HAVE_STRLCAT
+#if HAVE_STRLCAT
 #define SDL_strlcat strlcat
 #else
 extern DECLSPEC size_t SDLCALL SDL_strlcat(char *dst, const char *src, size_t maxlen);
 #endif
 
-#ifdef HAVE_STRDUP
+#if HAVE_STRDUP
 #define SDL_strdup strdup
 #else
 extern DECLSPEC char * SDLCALL SDL_strdup(const char *string);
 #endif
 
-#ifdef HAVE__STRREV
+#if HAVE__STRREV
 #define SDL_strrev _strrev
 #else
 extern DECLSPEC char * SDLCALL SDL_strrev(char *string);
 #endif
 
-#ifdef HAVE__STRUPR
+#if HAVE__STRUPR
 #define SDL_strupr _strupr
 #else
 extern DECLSPEC char * SDLCALL SDL_strupr(char *string);
 #endif
 
-#ifdef HAVE__STRLWR
+#if HAVE__STRLWR
 #define SDL_strlwr _strlwr
 #else
 extern DECLSPEC char * SDLCALL SDL_strlwr(char *string);
 #endif
 
-#ifdef HAVE_STRCHR
+#if HAVE_STRCHR
 #define SDL_strchr strchr
 #else
 extern DECLSPEC char * SDLCALL SDL_strchr(const char *string, int c);
 #endif
 
-#ifdef HAVE_STRRCHR
+#if HAVE_STRRCHR
 #define SDL_strrchr strrchr
 #else
 extern DECLSPEC char * SDLCALL SDL_strrchr(const char *string, int c);
 #endif
 
-#ifdef HAVE_STRSTR
+#if HAVE_STRSTR
 #define SDL_strstr strstr
 #else
 extern DECLSPEC char * SDLCALL SDL_strstr(const char *haystack, const char *needle);
 #endif
 
-#ifdef HAVE__LTOA
+#if HAVE__LTOA
 #define SDL_ltoa _ltoa
 #else
 extern DECLSPEC char * SDLCALL SDL_ltoa(long value, char *string, int radix);
 #endif
 
-#ifdef HAVE__ULTOA
+#if HAVE__ULTOA
 #define SDL_ultoa _ultoa
 #else
 extern DECLSPEC char * SDLCALL SDL_ultoa(unsigned long value, char *string, int radix);
 #endif
 
-#ifdef HAVE_STRTOL
+#if HAVE_STRTOL
 #define SDL_strtol strtol
 #else
 extern DECLSPEC long SDLCALL SDL_strtol(const char *string, char **endp, int base);
 #endif
 
-#ifdef HAVE_STRTOUL
+#if HAVE_STRTOUL
 #define SDL_strtoul strtoul
 #else
 extern DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *string, char **endp, int base);
 #endif
 
-#ifdef HAVE__I64TOA
+#if HAVE__I64TOA
 #define SDL_lltoa _i64toa
 #else
 extern DECLSPEC char* SDLCALL SDL_lltoa(Sint64 value, char *string, int radix);
 #endif
 
-#ifdef HAVE__UI64TOA
+#if HAVE__UI64TOA
 #define SDL_ulltoa _ui64toa
 #else
 extern DECLSPEC char* SDLCALL SDL_ulltoa(Uint64 value, char *string, int radix);
 #endif
 
-#ifdef HAVE__STRTOI64
+#if HAVE__STRTOI64
 #define SDL_strtoll _strtoi64
-#elif defined(HAVE_STRTOLL)
+#elif HAVE_STRTOLL
 #define SDL_strtoll strtoll
 #else
 extern DECLSPEC Sint64 SDLCALL SDL_strtoll(const char *string, char **endp, int base);
 #endif
 
-#ifdef HAVE__STRTOUI64
+#if HAVE__STRTOUI64
 #define SDL_strtoull _strtoui64
-#elif defined(HAVE_STRTOULL)
+#elif HAVE_STRTOULL
 #define SDL_strtoull strtoull
 #else
 extern DECLSPEC Uint64 SDLCALL SDL_strtoull(const char *string, char **endp, int base);
 #endif
 
-#ifdef HAVE_STRTOD
+#if HAVE_STRTOD
 #define SDL_strtod strtod
 #else
 extern DECLSPEC double SDLCALL SDL_strtod(const char *string, char **endp);
 #endif
 
-#ifdef HAVE_STRCMP
+#if HAVE_STRCMP
 #define SDL_strcmp strcmp
 #else
 extern DECLSPEC int SDLCALL SDL_strcmp(const char *str1, const char *str2);
 #endif
 
-#ifdef HAVE_STRNCMP
+#if HAVE_STRNCMP
 #define SDL_strncmp strncmp
 #else
 extern DECLSPEC int SDLCALL SDL_strncmp(const char *str1, const char *str2, size_t maxlen);
 #endif
 
-#ifdef HAVE_STRCASECMP
+#if HAVE_STRCASECMP
 #define SDL_strcasecmp strcasecmp
-#elif defined(HAVE__STRICMP)
+#elif HAVE__STRICMP
 #define SDL_strcasecmp _stricmp
 #else
 extern DECLSPEC int SDLCALL SDL_strcasecmp(const char *str1, const char *str2);
 #endif
 
-#ifdef HAVE_STRNCASECMP
+#if HAVE_STRNCASECMP
 #define SDL_strncasecmp strncasecmp
-#elif defined(HAVE__STRNICMP)
+#elif HAVE__STRNICMP
 #define SDL_strcasecmp _strnicmp
 #else
 extern DECLSPEC int SDLCALL SDL_strncasecmp(const char *str1, const char *str2, size_t maxlen);
 #endif
 
-#ifdef HAVE_SSCANF
+#if HAVE_SSCANF
 #define SDL_sscanf sscanf
 #else
 extern DECLSPEC int SDLCALL SDL_sscanf(const char *text, const char *fmt, ...);
 #endif
 
-#ifdef HAVE_SNPRINT
+#if HAVE_SNPRINT
 #define SDL_snprintf snprintf
 #else
 extern DECLSPEC int SDLCALL SDL_snprintf(char *text, size_t maxlen, const char *fmt, ...);
 #endif
 
-#ifdef HAVE_VSNPRINTF
+#if HAVE_VSNPRINTF
 #define SDL_vsnprintf vsnprintf
 #else
 extern DECLSPEC int SDLCALL SDL_vsnprintf(char *text, size_t maxlen, const char *fmt, va_list ap);
@@ -382,7 +382,7 @@ extern DECLSPEC int SDLCALL SDL_vsnprintf(char *text, size_t maxlen, const char 
     } \
   } while (0)
 
-#ifdef HAVE_ALLOCA
+#if HAVE_ALLOCA
 #define SDL_stack_alloc(type, count) (type*)alloca(sizeof(type)*(count))
 #define SDL_stack_free(data)
 #else


### PR DESCRIPTION
Other build systems can define these but to 0 when the feature is
unavailable, and include this header.