### PR TITLE
Make include logic closer to real SDL 1.2

### DIFF
--- a/include/SDL/SDL_stdinc.h
+++ b/include/SDL/SDL_stdinc.h
@@ -83,10 +83,9 @@ SDL_COMPILE_TIME_ASSERT(enum, sizeof(SDL_DUMMY_ENUM) == sizeof(int));
 #ifdef HAVE_STDIO_H
 #include <stdio.h>
 #endif
-#ifdef HAVE_STDLIB_H
+#if defined(HAVE_STDLIB_H)
 #include <stdlib.h>
-#endif
-#ifdef HAVE_MALLOC_H
+#elif defined(HAVE_MALLOC_H)
 #include <malloc.h>
 #endif
 #ifdef HAVE_STDDEF_H
@@ -101,10 +100,9 @@ SDL_COMPILE_TIME_ASSERT(enum, sizeof(SDL_DUMMY_ENUM) == sizeof(int));
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif
-#ifdef HAVE_INTTYPES_H
+#if defined(HAVE_INTTYPES_H)
 #include <inttypes.h>
-#endif
-#ifdef HAVE_STDINT_H
+#elif defined(HAVE_STDINT_H)
 #include <stdint.h>
 #endif
 #ifdef HAVE_CTYPE_H


### PR DESCRIPTION
This should offer better compatibility in some cases.

This PR is an alternative to #195. I think that one is probably better practice in general, but this one is taking more of a bug-for-bug compatibility approach, as may better fit the goals of sdl12-compat.