### PR TITLE
Set DYLIB_COMPAT_VERSION to match SDL-1.2 autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,10 @@ set(CMAKE_SKIP_RPATH TRUE)
 if(APPLE)
   set(OSX_SRCS "src/SDL12_compat_objc.m")
   set_source_files_properties(${OSX_SRCS} PROPERTIES LANGUAGE C)
-  # the following matches SDL-1.2 Xcode project file
-  set(DYLIB_COMPAT_VERSION 1.0.0 CACHE STRING "library compatibility version")
+  # compatibility version set to match SDL-1.2 autotools build
+  # Xcode project file uses 1.0.0, but it's more compatible to use the
+  # higher version.
+  set(DYLIB_COMPAT_VERSION 12.0.0 CACHE STRING "library compatibility version")
   set(DYLIB_CURRENT_VERSION 12.54.0 CACHE STRING "library current version")
   include_directories("/opt/X11/include")  # hack.
   if(CMAKE_VERSION VERSION_LESS 3.9)


### PR DESCRIPTION
The compatibility_version is meant to go up when new symbols are added
to a library, so an executable built against an older version of a
library can run against a newer version of that library, but not the
other way round. The most binary compatible approach is therefore to
use the highest of the different compatibility_version numbers that
could have been used by SDL-1.2.