### PR TITLE
RestoreDestAlpha: Fix out-of-bounds access to buffer

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -6138,8 +6138,8 @@ RestoreDestAlpha(SDL12_Surface *dst12, Uint8 *dstalpha, const SDL12_Rect *dstrec
     if (dstalpha) {
         int x, y;
 
-        const int w = dst12->w;
-        const int h = dst12->h;
+        const int w = dstrect12->w;
+        const int h = dstrect12->h;
         const Uint8 *sptr = dstalpha;
         const Uint32 amask = dst12->format->Amask;
         const Uint32 ashift = dst12->format->Ashift;


### PR DESCRIPTION
Since commit 812d58f, SaveDestAlpha only acts on a rectangle of size (dstrect12->w × dstrect12->h) at (dstrect12->x, dstrect12->y), but RestoreDestAlpha tries to act on a rectangle of size (dst12->w × dst12->h) at (dstrect12->x, dstrect12->y). For a non-trivial dstrect with x > 0 or y > 0, this resulted in invalid accesses outside the bounds of the pixel buffer and memory corruption.

Fixes: 812d58f "video: Optimize temporarily saving of dest alpha for a blit"  
Resolves: https://github.com/libsdl-org/sdl12-compat/issues/211