### PR TITLE
testiconv: Print the total number of errors at the end

### DIFF
--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -69,5 +69,7 @@ int main(int argc, char *argv[])
 		fputs(test[0], stdout);
 		SDL_free(test[0]);
 	}
+
+	fprintf(stderr, "\nTotal errors: %d\n", errors);
 	return (errors ? errors + 1 : 0);
 }


### PR DESCRIPTION
This helps make it more clear at a glance whether or not testiconv succeeded or not.

This change is copied from libsdl-org/SDL-1.2#868.