### PR TITLE
Clamp mouse coordinates to the backbuffer size for non-OpenGL

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -4512,6 +4512,9 @@ EventFilter20to12(void *data, SDL_Event *event20)
             event12.motion.which = (Uint8) event20->motion.which;
             event12.motion.state = event20->motion.state;
             AdjustOpenGLLogicalScalingPoint(&event20->motion.x, &event20->motion.y);
+            /* Clamp the absolute position to the window dimensions. */
+            event20->motion.x = SDL_max(SDL_min(event20->motion.x, VideoSurface12->w), 0);
+            event20->motion.y = SDL_max(SDL_min(event20->motion.y, VideoSurface12->h), 0);
             event12.motion.x = (Uint16) event20->motion.x;
             event12.motion.y = (Uint16) event20->motion.y;
             if (UseMouseRelativeScaling) {


### PR DESCRIPTION
When we're logically scaling, and preserving the aspect ratio (so are letterboxing or pillarboxing), the scaled mouse coordinates may be outside the application window (backbuffer). These can even be negative, which get underflowed to very large positive values, as SDL 1.2 uses unsigned coordinates here.

We were already clamping these values for OpenGL logical scaling, which we do ourselves, but the event filter used with SDL_Renderer doesn't, so we'll manually clamp these all the time.

The issue could be reproduced in Civilization: Call To Power, by starting the game windowed 1024×768 (or another 4:3 resolution), maximising the window (which, if you have a widescreen display, will pillarbox), and starting a game. When pushing the mouse to the left edge to scroll, you have to very precisely stay within the window. If the mouse ends up in the pillarbox region, the game map will scroll the other way, as the negative mouse coordinate will underflow, and the game will treat that as scrolling to the right.