### PR TITLE
cmake: make sure all libraries in CMAKE_DL_LIBS are added with -l prefix to .pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(SDL12DEVEL "Enable installing SDL-1.2 development headers" ON)
 option(STATICDEVEL "Enable installing static link library" OFF)
 
 if(STATICDEVEL AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
-  MESSAGE(FATAL_ERROR "Static builds are only supported on Linux.")
+  message(FATAL_ERROR "Static builds are only supported on Linux.")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ elseif(WIN32)
     set_target_properties(SDL PROPERTIES
         VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
-      OUTPUT_NAME "SDL")
+        OUTPUT_NAME "SDL")
 elseif(OS2)
     set_target_properties(SDL PROPERTIES COMPILE_DEFINITIONS "BUILD_SDL") # for DECLSPEC
     set_target_properties(SDL PROPERTIES
@@ -113,7 +113,7 @@ else()
     set_target_properties(SDL PROPERTIES
         VERSION "${PROJECT_VERSION}"
         SOVERSION "0"
-      OUTPUT_NAME "SDL")
+        OUTPUT_NAME "SDL")
 endif()
 
 if(MINGW)
@@ -262,7 +262,10 @@ if(SDL12DEVEL)
       set(SDL_CFLAGS "-D_GNU_SOURCE=1 -D_REENTRANT")
       set(SDL_RLD_FLAGS "")  # !!! FIXME: this forces rpath, which we might want?
       set(SDL_LIBS "-lSDL")
-      set(SDL_STATIC_LIBS ${CMAKE_DL_LIBS})
+      set(SDL_STATIC_LIBS "")
+      foreach(lib ${CMAKE_DL_LIBS})
+          set(SDL_STATIC_LIBS "-l${lib}")
+      endforeach()
       if(NOT STATICDEVEL)
         set(SDL_STATIC_LIBS "")
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ if(STATICDEVEL AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
   MESSAGE(FATAL_ERROR "Static builds are only supported on Linux.")
 endif()
 
+include(CheckCSourceCompiles)
+include(CheckIncludeFile)
+include(CheckCCompilerFlag)
+include(GNUInstallDirs)
+
 set(CMAKE_SKIP_RPATH TRUE)
 
 if(APPLE)
@@ -43,11 +48,6 @@ set(SDL12COMPAT_SRCS
 )
 add_library(SDL SHARED ${SDL12COMPAT_SRCS})
 
-include(CheckCSourceCompiles)
-include(CheckIncludeFile)
-include(CheckCCompilerFlag)
-
-include(GNUInstallDirs)
 include("cmake/modules/FindSDL2.cmake")
 target_include_directories(SDL PRIVATE ${SDL2_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ if(STATICDEVEL AND NOT (CMAKE_SYSTEM_NAME MATCHES "Linux"))
   MESSAGE(FATAL_ERROR "Static builds are only supported on Linux.")
 endif()
 
+list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_LIST_DIR}/cmake/modules"
+)
+
 include(CheckCSourceCompiles)
 include(CheckIncludeFile)
 include(CheckCCompilerFlag)
@@ -48,7 +52,10 @@ set(SDL12COMPAT_SRCS
 )
 add_library(SDL SHARED ${SDL12COMPAT_SRCS})
 
-include("cmake/modules/FindSDL2.cmake")
+find_package(SDL2)
+if(NOT SDL2_INCLUDE_DIRS)
+  message(FATAL_ERROR "Could not find SDL2 headers")
+endif()
 target_include_directories(SDL PRIVATE ${SDL2_INCLUDE_DIRS})
 
 set(EXTRA_CFLAGS )


### PR DESCRIPTION
- find SDL2 through [`find_package`](https://cmake.org/cmake/help/latest/command/find_package.html)
- prepend all values in `CMAKE_DL_LIBS` with `-l`, for use in the `.pc` file.
  The CMake script unconditionally uses `dl`, even if `dlopen` is available in the c library.
  This is also what's documented in the [dlopen manual](https://man7.org/linux/man-pages/man3/dlopen.3.html).

Fixes #222