### PR TITLE
cdrom: Fix end offset calulcation in SDL_CDPlay

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -8701,12 +8701,12 @@ SDL_CDPlay(SDL12_CD *cdrom, int start, int length)
 
     start_frame = start - cdrom->track[start_track].offset;
 
-    if (remain < (cdrom->track[start_frame].length - start_frame)) {
+    if (remain < (cdrom->track[start_track].length - start_frame)) {
         ntracks = 0;
         nframes = remain;
         remain = 0;
     } else {
-        remain -= (cdrom->track[start_frame].length - start_frame);
+        remain -= (cdrom->track[start_track].length - start_frame);
         for (i = start_track + 1; i < cdrom->numtracks; i++) {
             if (remain < cdrom->track[i].length) {
                 ntracks = i - start_track;


### PR DESCRIPTION
We were accidentally using the frame number instead of the track number to lookup a track, which not only resulted in playback cutting off in the middle of tracks, but also probably accessed a bunch of invalid memory.

This fixes CivCTP, which does still seem to play each track twice in a row, though that might be the game's intended behavour. Otherwise (along with one more nasty binary patch to work around the game's recursive mutex implementation) it now is absolutely rock-solid on my machines.