### PR TITLE
quirks: Force X11 if plib (specifically libplibssg) is detected

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1368,6 +1368,8 @@ LoadSDL20(void)
                 force_x11 = SDL_TRUE;
             } else if (dlsym(global_symbols, "cgGLEnableProgramProfiles") != NULL) {  /* NVIDIA Cg (e.g. Awesomenauts, Braid) */
                 force_x11 = SDL_TRUE;
+            } else if (dlsym(global_symbols, "_Z7ssgInitv") != NULL) {  /* ::ssgInit(void) in plib (e.g. crrcsim) */
+                force_x11 = SDL_TRUE;
             }
             dlclose(global_symbols);
         }


### PR DESCRIPTION
crrcsim, a model aeroplane simulator, is linked to both SDL 1.2 and plib. I'm not entirely sure why, since plib seems to be an (unmaintained) alternative to SDL that did many of the same things.

Because plib has a C++ ABI but dlsym() works with C-level ABI, we need to use a C++ mangled name for the symbol we look for.

Resolves: https://github.com/libsdl-org/sdl12-compat/issues/252
