### PR TITLE
MLT fix

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -7660,9 +7660,10 @@ SDL_DisplayYUVOverlay(SDL12_Overlay *overlay12, SDL12_Rect *dstrect12)
 DECLSPEC12 void SDLCALL
 SDL_UnlockYUVOverlay(SDL12_Overlay *overlay12)
 {
-    if (overlay12) {
+    /* MLT SDL1 consumer uses locks, but accesses pixels pointer outside the lock, so don't null the pixels pointer. */
+    /*if (overlay12) {
         overlay12->pixels = NULL;
-    }
+    }*/
 }
 
 DECLSPEC12 void SDLCALL


### PR DESCRIPTION
Please consider and comment on this change to fix MLT SDL1 consumer.
Without this change Flowblade video editor crashes, when using the sdl12-compat layer.
See issue https://github.com/jliljebl/flowblade/issues/1061

edit: the changes included a fix to infinite loop in SDL_FreeYUVOverlay, but another fix is already in main branch, so it's not included anymore. (see: https://github.com/libsdl-org/sdl12-compat/commit/683234e8708a081224942181710ca5dd3cee409e )
That change is also required to fix Flowblade hanging.

Do you prefer the fix here, or should I submit patches to MLT instead, to avoid using pixels pointer without lock?