### PR TITLE
SysWW/X11: Return the X11 window as wmwindow and x11window

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -7439,8 +7439,9 @@ SDL_GetWMInfo(SDL12_SysWMinfo *info12)
         info12->info.x11.display = info20.info.x11.display;
         info12->info.x11.window = temp_window ? 0 : info20.info.x11.window;
         if (SDL_VERSIONNUM(info12->version.major, info12->version.minor, info12->version.patch) >= SDL_VERSIONNUM(1, 0, 2)) {
-            info12->info.x11.fswindow = 0;  /* these don't exist in SDL2. */
-            info12->info.x11.wmwindow = 0;
+            /* While these don't exist in SDL2, some programs expect to get a valid window anyway. */
+            info12->info.x11.fswindow = temp_window ? 0 : info20.info.x11.window;
+            info12->info.x11.wmwindow = temp_window ? 0 : info20.info.x11.window;
         }
         if (SDL_VERSIONNUM(info12->version.major, info12->version.minor, info12->version.patch) >= SDL_VERSIONNUM(1, 2, 12)) {
             info12->info.x11.gfxdisplay = info20.info.x11.display;  /* shrug */


### PR DESCRIPTION
Steel Storm (and presumably other darkplaces, SDL 1.2-based games) expect x11.wmwindow to be valid if they've created a window and are running under X11. Just pass the same game window like we do for x11.window.

See the old darkplaces code here:
https://github.com/xonotic/darkplaces/blob/a0465ad2ee16719587b0b7a80d4c1c2f7df1ac0e/vid_sdl.c#L2334

This should fix the BadWindow errors on Steel Storm Burning Retribution (issue #290)