### PR TITLE
Check for undefined TARGET_OS_*

### DIFF
--- a/include/SDL/SDL_platform.h
+++ b/include/SDL/SDL_platform.h
@@ -72,11 +72,11 @@ requirement is dropped too. Send patches. :) */
 /* lets us know what version of Mac OS X we're compiling on */
 #include "AvailabilityMacros.h"
 #include "TargetConditionals.h"
-#if TARGET_OS_TV
+#if defined(TARGET_OS_TV) && TARGET_OS_TV
 #undef __TVOS__
 #define __TVOS__ 1
 #endif
-#if TARGET_OS_IPHONE
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 /* if compiling for iOS */
 #undef __IPHONEOS__
 #define __IPHONEOS__ 1


### PR DESCRIPTION
Prevents some versions of clang from erroring out like this:
```
error: 'TARGET_OS_TV' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
```