### PR TITLE
SDL_config.h: Assume that all platforms have ISO C89 stddef.h

### DIFF
--- a/include/SDL/SDL_config.h
+++ b/include/SDL/SDL_config.h
@@ -54,6 +54,8 @@ typedef unsigned __int64 uint64_t;
 #include <stdarg.h>
 #define HAVE_STDARG_H 1
 
+#define HAVE_STDDEF_H 1
+
 /* for now, let's try and say everything that we care about that isn't Windows
 has these C runtime functions available. We're trying to avoid a configure
 stage, though. Send patches if your platform lacks something. */


### PR DESCRIPTION
sdl12-compat's SDL_stdinc.h includes `<stddef.h>` if `HAVE_STDDEF_H` is defined, but until now there was nothing that would have defined that macro. In classic SDL 1.2, SDL_stdinc.h historically included this, and some games (such as Debian package 'berusky') rely on it.

stddef.h is required by ISO C89, and is unconditionally included in the headers of some widely portable libraries like libdbus, so it seems safe to assume that all platforms have it (including Windows) unless we hear otherwise.

Resolves: https://github.com/libsdl-org/sdl12-compat/issues/297