### PR TITLE
include: Use `struct private_hwdata` incomplete type for API compat

### DIFF
--- a/include/SDL/SDL_video.h
+++ b/include/SDL/SDL_video.h
@@ -89,7 +89,7 @@ typedef struct SDL_Surface
     Uint16 pitch;
     void *pixels;
     int offset;
-    void *hwdata;
+    struct private_hwdata *hwdata;
     SDL_Rect clip_rect;
     Uint32 unused1;
     Uint32 locked;


### PR DESCRIPTION
Classic SDL 1.2 headers traditionally had this member as a pointer to the incomplete type `struct private_hwdata`. For whatever reason (presumably a sense of completeness) the SDLmm C++ binding[1] that is bundled in Debian package 'asc' (Advanced Strategic Command) defines an accessor for it, which is declared as returning `struct private_hwdata *` and has the obvious trivial implementation[2].

Implicit conversion from `void *` to `struct private_hwdata *` is allowed in C, but not in C++, so sdl12-classic's simplification of changing this member from `struct private_hwdata *` to `void *` breaks the build for SDLmm.

Arguably it's a bug that SDLmm has this accessor, because this member is for internal use by SDL and its type has no public definition, so there's no legitimate reason for third-party code to call the accessor; but it does exist, so 100% source compatibility with classic SDL 1.2 would require it to have the same type it historically had.

[1] https://sourceforge.net/projects/sdlmm/  
[2] https://sourceforge.net/p/sdlmm/code/HEAD/tree/trunk/SDLmm/src/sdlmm_basesurface.h#l141

Resolves: https://github.com/libsdl-org/sdl12-compat/issues/299

---

If the sdl12-compat maintainers prefer to reject this PR as "SDLmm is wrong, sdl12-compat is already fine" then the change to fix compilation of asc should be as simple as deleting the `hwdata` accessor, which asc never calls anyway.