### PR TITLE
SDL_config: Define HAVE_MALLOC_H on glibc-based platforms

### DIFF
--- a/include/SDL/SDL_config.h
+++ b/include/SDL/SDL_config.h
@@ -129,9 +129,13 @@ stage, though. Send patches if your platform lacks something. */
 #endif
 #endif
 
+#if defined(__GLIBC__)
+/* glibc certainly includes this, send patches if your OS does too */
+#define HAVE_MALLOC_H 1
+#endif
+
 /* things that aren't necessarily in Linux, some are MSVC C runtime, some are BSD. Send patches. */
 #if 0
-#define HAVE_MALLOC_H 1
 #define HAVE_BCOPY 1
 #define HAVE_ATOI 1
 #define HAVE_ATOF 1


### PR DESCRIPTION
Version 3.7.4 of the Freespace 2 Source Code Project is known to rely on SDL having checked for this, and won't see a declaration of malloc_usable_size() if we don't.

This is a workaround for source compatibility with classic SDL 1.2: if a game wants to use functions from a particular system header file, it should be that game's responsibility to check for the header file itself.

Bug-Debian: https://bugs.debian.org/1012232#58

---

Same sort of idea as #299, providing bug-for-bug compatibility with SDL 1.2 in places where it breaks compilation of old SDL 1.2 codebases. (At this point I have *almost* compiled all of Debian's remaining SDL 1.2 packages against sdl12-compat...)