### PR TITLE
Add null check to SDL_LoadWAV_RW to avoid crashes

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -8454,6 +8454,10 @@ SDL_LoadWAV_RW(SDL12_RWops *rwops12, int freerwops12,
     SDL_RWops *rwops20 = RWops12to20(rwops12);
     SDL_AudioSpec *retval = NULL;
 
+    if (!rwops20) {
+        return NULL;
+    }
+
     *buf = NULL;
 
     /* SDL2's LoadWAV requires a seekable stream, but SDL 1.2 didn't,

--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -8454,11 +8454,11 @@ SDL_LoadWAV_RW(SDL12_RWops *rwops12, int freerwops12,
     SDL_RWops *rwops20 = RWops12to20(rwops12);
     SDL_AudioSpec *retval = NULL;
 
+    *buf = NULL;
+
     if (!rwops20) {
         return NULL;
     }
-
-    *buf = NULL;
 
     /* SDL2's LoadWAV requires a seekable stream, but SDL 1.2 didn't,
        so if the stream appears unseekable, try to load it into a


### PR DESCRIPTION
Native SDL 1.2 and 2.0 both handle SDL_LoadWAV(null,...), SDL_LoadWAV("",...) and SDL_LoadWAV(nonexistent_file,...) by returning NULL and setting an error; this check resores that behavior.

Fixes https://github.com/libsdl-org/sdl12-compat/issues/310