### PR TITLE
Avoid SDL_GetMouseState(), which returns raw coordinates (fixes #318)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -7294,12 +7294,6 @@ UpdateRelativeMouseMode(void)
         const SDL_bool enable = (VideoWindowGrabbed && VideoCursorHidden) ? SDL_TRUE : SDL_FALSE;
         if (MouseInputIsRelative != enable) {
             MouseInputIsRelative = enable;
-            if (MouseInputIsRelative) {
-                /* reset position, we'll have to track it ourselves in SDL_MOUSEMOTION events, since 1.2
-                 * would give you window coordinates, even in relative mode. */
-                SDL20_GetMouseState(&MousePosition.x, &MousePosition.y);
-                AdjustOpenGLLogicalScalingPoint(&MousePosition.x, &MousePosition.y);
-            }
             SDL20_SetRelativeMouseMode(MouseInputIsRelative);
         }
     }


### PR DESCRIPTION
sdl12-compat tracks the mouse position in the MousePosition variable, even when we're not in relative mouse mode. We therefore don't need to call SDL20_GetMouseState() to update it before entering relative mouse mode: we already have it from the last SDL_MOUSEMOTION event, and have already applied any scaling we need.

This is important, because SDL_GetMouseState() returns the _raw_ mouse coordinates, not the ones scaled by SDL_RenderSetLogicalSize(). So we end up with a mismatch. This results in a mouse offset on non-OpenGL, scaled games, like Alpha Centauri in fullscreen (see #318).

We could fix this by calling SDL_RenderWindowToLogical() instead, but that complicates the codepath as we don't always have an SDL_Renderer (we might be using OpenGL), so this seems cleaner.

I've tested this with SMAC (where it fixes the bug) and Wolf4SDL (which was cited in the commit which introduced this check). Both work fine.