### PR TITLE
Add a SDL12COMPAT_MAX_BPP hint, and use it to restrict Hyperspace Delivery Boy to 16bpp (fixes #317)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1274,6 +1274,10 @@ static QuirkEntryType quirks[] = {
     {"fillets", "SDL12COMPAT_ALLOW_SYSWM", "0"},
     {"fillets", "SDL12COMPAT_COMPATIBILITY_AUDIOCVT", "1"},
 
+    /* Hyperspace Delivery Boy relies on the exact imprecision of the format conversion in some 
+       earlier versions of SDL 1.2. It also recommends 16-bit in the README, so force it. */
+    {"hdb", "SDL12COMPAT_MAX_BPP", "16"},
+
     /* Mark of the Ninja doesn't work with OpenGL scaling */
     {"ninja-bin32", "SDL12COMPAT_OPENGL_SCALING", "0"},
     {"ninja-bin64", "SDL12COMPAT_OPENGL_SCALING", "0"},


### PR DESCRIPTION
Some games (e.g. Hyperspace Delivery Boy) only work on a 16-bit display,
but request the highest bit-depth available. Add a hint which makes all
queries for a mode (including the current mode, and the implicit format
chosen by providng SDL_SetVideoMode() a bpp of 0) report a bit depth
less than or equal to the value of SDL12COMPAT_FORCE_BPP.

We then add a quirk to force Hyperspace Delivery Boy to 16-bit, as it uses
the current video mode's bpp, but for 32-bit modes relies heavily on the
exact way format conversion was broken in some SDL 1.2 versions.

There are a few interesting "features" of this implementation:
- All video modes are now clamped to 32bit, which is the default value
  of the hint. This seems like something we'd probably want anyway, as
  many SDL 1.2 apps would have trouble with >32bit video modes anway
  (and we never properly supported them).
- This is our first proper integer hint, so add an SDL_GetHintInt()
  function.
- Split the BPP -> format conversion into its own helper function.
- This doesn't clamp the bit depth of user-created surfaces, or of the
  screen if the application specifically requests a bit depth. It only
  changes defaults and reported modes.

Regardless, this seems, at least to me, to be a better solution than trying
to emulate all of the ways different versions of SDL 1.2 could get format
conversion wrong. And, if you're bored, you can force games to run at 8bpp
and enjoy the horrible colour banding.