### PR TITLE
README: Document SDL12COMPAT_NO_QUIT_VIDEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ The available options are:
   backends, because SDL 1.2 didn't have wide support for its SysWM APIs
   outside of Windows and X11 anyhow.
 
+- SDL12COMPAT_NO_QUIT_VIDEO: (checked during SDL_QuitSubsystem)
+  If enabled, SDL_Quit() and SDL_QuitSubsystem() will never shut down the
+  video subsystem. This works around buggy applications which try to use
+  the video subsystem after shutting it down.
+
 
 # Compatibility issues with OpenGL scaling
 


### PR DESCRIPTION
This hint was never documented in README.md, even though it was used in a quirk, and mentioned briefly in COMPATIBILITY.md.

There's possibly a point where README.md might not be the best place for an exhaustive list of hints/quirks, particularly if they get very obscure or game-specific. Though given this now seems to help multiple applications, it's probably okay. But maybe we'll get to a point where it's worth only mentioning the most common in README.md, and moving the rest to a separate HINTS.md.

Fixes #329.