### PR TITLE
quirks: Add SDL12COMPAT_COMPATIBILITY_AUDIOCVT=1 to "heroes3.dynamic"

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1303,6 +1303,9 @@ static QuirkEntryType quirks[] = {
     /* boswars has a bug where SDL_AudioCVT must not require extra buffer space. See Issue #232. */
     {"boswars", "SDL12COMPAT_COMPATIBILITY_AUDIOCVT", "1"},
 
+    /* Loki HOMM3 */
+    {"heroes3.dynamic", "SDL12COMPAT_COMPATIBILITY_AUDIOCVT", "1"},
+
     /* grafx2 tries to do all sorts of stuff by talking directly to the X server, causing problems. */
     {"grafx2", "SDL12COMPAT_ALLOW_SYSWM", "0"},
 


### PR DESCRIPTION
Don't ask my why this is needed, but without it the game just freeze/crash after the intro video:

```
INFO: This app is looking for CD-ROM drives, but no path was specified
INFO: Set the SDL12COMPAT_FAKE_CDROM_PATH environment variable to a directory
INFO: of MP3 files named trackXX.mp3 where XX is a track number in two digits
INFO: from 01 to 99
double free or corruption (!prev)

BUG!  Exception triggered, cleaning up.
Heroes of Might & Magic III 1.3.1a
Built with glibc-2.1 on x86
Stack dump:
{
```