### PR TITLE
quirks: Closure needs OpenGL scaling disabled (Fix #342)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1257,6 +1257,10 @@ static QuirkEntryType quirks[] = {
     /* Braid uses Cg, which uses glXGetProcAddress(). */
     {"braid", "SDL12COMPAT_OPENGL_SCALING", "0"},
 
+    /* Closure uses Cg, and doesn't render anything with OpenGL scaling. */
+    {"Closure.bin.x86", "SDL12COMPAT_OPENGL_SCALING", "0"},
+    {"Closure.bin.x86_64", "SDL12COMPAT_OPENGL_SCALING", "0"},
+
     /* GOG's DOSBox builds have architecture-specific filenames. */
     {"dosbox", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"},
     {"dosbox_i686", "SDL12COMPAT_USE_KEYBOARD_LAYOUT", "0"},


### PR DESCRIPTION
Closure uses Cg, and also generally doesn't play nicely with OpenGL scaling, resulting in a black screen. Disabling OpenGL scaling lets the game work properly, so add a quirk to do this by default.

Tested against the Humble Indie Bundle 7 build (Closure-Linux-1.1-2012-12-28.sh), and it seems to work fine.