### PR TITLE
video: Reflect SDL12_RESIZABLE in SDL12_Surface->flags

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -6469,6 +6469,12 @@ SetVideoModeImpl(int width, int height, int bpp, Uint32 flags12)
         VideoSurface12->flags &= ~SDL12_FULLSCREEN;
     }
 
+    if (flags12 & SDL12_RESIZABLE) {
+        VideoSurface12->flags |= SDL12_RESIZABLE;
+    } else {
+        VideoSurface12->flags &= ~SDL12_RESIZABLE;
+    }
+
     if (flags12 & SDL12_OPENGL) {
         SDL_assert(!VideoTexture20);  /* either a new window or we destroyed all this */
         SDL_assert(!VideoRenderer20);


### PR DESCRIPTION
Code depends on being able to see the RESIZABLE flag in video surfaces. For example, the Perl module SDLx::App will throw an error if it tries to resize a surface but doesn't find SDL_RESIZABLE in its flags:

<https://metacpan.org/release/FROGGS/SDL-2.548/source/lib/SDLx/App.pm#L143>

To improve compatibility with such code, copy the flag to the VideoSurface12 created in SDL_SetVideoMode.