### PR TITLE
StartCDAudioPlaying(): change the local var pcm_frame into 32 bits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,12 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { name: Windows, os: windows-latest }
+        - { name: Windows-MSVC-x86, os: windows-latest, flags: -A Win32 }
+        - { name: Windows-MSVC-x64, os: windows-latest, flags: -A x64 }
         - { name: Linux-x86_64, os: ubuntu-24.04, flags: -GNinja }
         - { name: Linux-arm64, os: ubuntu-24.04-arm, flags: -GNinja }
-        - { name: MacOS-arm, os: macos-latest }
-        - { name: MacOS-intel, os: macos-13 }
+        - { name: MacOS-arm64, os: macos-latest }
+        - { name: MacOS-x86_64, os: macos-13 }
     steps:
     - name: Setup Linux dependencies
       if: startsWith(runner.os, 'Linux')

--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -9231,7 +9231,7 @@ StartCDAudioPlaying(SDL12_CD *cdrom, const int start_track, const int start_fram
     drmp3 *mp3 = (drmp3 *) SDL20_malloc(sizeof (drmp3));
     const SDL_bool loaded = mp3 ? LoadCDTrack(start_track, mp3) : SDL_FALSE;
     const SDL_bool seeking = (loaded && (start_frame > 0))? SDL_TRUE : SDL_FALSE;
-    const drmp3_uint64 pcm_frame = seeking ? ((drmp3_uint64) ((start_frame / 75.0) * mp3->sampleRate)) : 0;
+    const drmp3_uint32 pcm_frame = seeking ? (Uint32) ((start_frame / 75.0) * (Sint32)mp3->sampleRate) : 0;
 
     if (!mp3) {
         return SDL20_OutOfMemory();


### PR DESCRIPTION
Avoids new MSVC emitting __ftoul2_legacy() in x86 builds which we don't
provide:  Fixes https://github.com/libsdl-org/sdl12-compat/issues/352.

Also update CI and run MSVC workflow for both x86 and x64.
TODO: Maybe support MinGW (both GCC- and Clang-based) workflows?

(CC @playmer )
