### PR TITLE
Revert "Rename sdl12_compat.pc to sdl.pc"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #        you can define SDL2_INCLUDE_DIR on the cmdline.  For example:
 #        cmake -DSDL2_INCLUDE_DIR=/opt/SDL2/include/SDL2 [other stuff]
 
-cmake_minimum_required(VERSION 3.0...3.10)
+cmake_minimum_required(VERSION 3.0.0...3.10)
 project(sdl12_compat
         VERSION 1.2.69
         LANGUAGES C)
@@ -40,6 +40,7 @@ if(APPLE)
     cmake_policy(SET CMP0068 NEW)  # on macOS, don't let RPATH affect install_name.
   endif()
 endif()
+
 if(WIN32)
   set(WIN32_SRCS "src/version.rc")
 endif()
@@ -280,8 +281,8 @@ if(SDL12DEVEL)
     set(ENABLE_SHARED_TRUE "")
     set(ENABLE_SHARED_FALSE "#")
 
-    configure_file(sdl.pc.in sdl.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdl.pc
+    configure_file(sdl12_compat.pc.in sdl12_compat.pc @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sdl12_compat.pc
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )
 

--- a/sdl12_compat.pc.in
+++ b/sdl12_compat.pc.in
@@ -8,7 +8,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: sdl12_compat
 Description: An SDL-1.2 compatibility layer that uses SDL 2.0 behind the scenes.
 Version: @PROJECT_VERSION@
-Provides: sdl = @PROJECT_VERSION@, sdl12_compat = @PROJECT_VERSION@
+Provides: sdl = @PROJECT_VERSION@
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@
 @ENABLE_STATIC_TRUE@Libs.private: -L${libdir} @SDL_LIBS@ @SDL_STATIC_LIBS@
 Cflags: -I${includedir}/SDL @SDL_CFLAGS@


### PR DESCRIPTION
This is unnecessary, given that everyone uses `pkgconf(1)`, which fully supports the `Provides:` stanza and expresses it in dependencies.

This reverts commit f10920239783dc09bd22f09bad69585cfce8a28d.