### PR TITLE
Add a new quirk 'SDL12COMPAT_NO_UNLOAD', usable/needed by SC3U

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1433,6 +1433,9 @@ static QuirkEntryType quirks[] = {
     /* The 32-bit Steam build only of Multiwinia Quits but doesn't re-Init */
     {"multiwinia.bin.x86", "SDL12COMPAT_NO_QUIT_VIDEO", "1"},
 
+    /* SimCity 3000 tries to call SDL_DestroyMutex after we have been unloaded */
+    {"sc3u.dynamic", "SDL12COMPAT_NO_UNLOAD", "1"},
+
     /* Loki Unreal Tournament '99 runs at hyperspeed if the framerate is too high. Force it to vsync. You should use the newer OldUnreal binaries with SDL2 instead! */
     {"ut-bin", "SDL12COMPAT_SYNC_TO_VBLANK", "1"}
 #else
@@ -1784,7 +1787,9 @@ static void dllinit(void)
 static void dllquit(void) __attribute__((destructor));
 static void dllquit(void)
 {
-    UnloadSDL20();
+    if (!SDL12Compat_GetHintBoolean("SDL12COMPAT_NO_UNLOAD", SDL_FALSE)) {
+        UnloadSDL20();
+    }
 }
 
 #elif defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__) || defined(__WATCOMC__))


### PR DESCRIPTION
This fixes the segfault when exiting the game described in #339

I don't really know if the path I choose to fix this is the right one, as I don't have a complete technical understanding of what's happening (but I guess the difference between a real SDL-1.2 and sdl12-compat is that fact that we explicitly calls `dlclose()` here)