### PR TITLE
SDL_CreateRGBSurface: Don't assert SDL_PREALLOC not set on 0-sized surfaces (width and/or height are 0)

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -5487,7 +5487,7 @@ SDL_CreateRGBSurface(Uint32 flags12, int width, int height, int depth, Uint32 Rm
         return NULL;
     }
 
-    SDL_assert((surface12->flags & ~(SDL12_SRCCOLORKEY|SDL12_SRCALPHA)) == 0);  /* shouldn't have prealloc, rleaccel, or dontfree. */
+    SDL_assert(!(width && height) || ((surface12->flags & ~(SDL12_SRCCOLORKEY|SDL12_SRCALPHA))) == 0);  /* shouldn't have prealloc, rleaccel, or dontfree. */
     Surface12SetMasks(surface12, Rmask, Gmask, Bmask, Amask);
     return surface12;
 }


### PR DESCRIPTION
SDL_CreateRGBSurface currently asserts that SDL_PREALLOC is not set. However, if the surface is empty (width or height are zero), then it doesn't matter if pixels is valid.

SDL2 does allocate an "empty" pixels, and so doesn't set SDL_PREALLOCATED, but SDL3 (including via sdl2compat) doesn't, leaving the empty SDL_Surface with SDL_PREALLOCATED (so it doesn't try to free the NULL pointer).

This _could_ be worked around in sdl2compat, but the SDL3/sdl2compat behaviour does make sense, and it's only the zealous assertion here which breaks.

Civilization: Call To Power triggers this by trying to create a bunch of 0×0 surfaces at startup, and is fixed by this patch.

Fixes: 13efe605cc42 ("Factor out enough of SDL_CreateRGBSurface to create surfaces in-place")