### PR TITLE
Hint: Add SDL12COMPAT_WINDOWED_MODE_LIST hint, to make SDL_ListModes() work in windowed mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ The available options are:
   video subsystem. This works around buggy applications which try to use
   the video subsystem after shutting it down.
 
+- SDL12COMPAT_WINDOWED_MODE_LIST: (checked during SDL_ListModes)
+  If enabled, returns the list of available video modes in SDL_ListModes(),
+  even if the flags provided do not include SDL_FULLSCREEN. Otherwise
+  (by default), it will return -1 to tell the application that all modes
+  are available. This may cause some applications to fall back to an internal
+  list, which may not be as exhaustive as the one sdl12-compat provides.
+  Try this if a game is not listing all of the screen resolutions it should
+  support.
+
 
 # Compatibility issues with OpenGL scaling
 

--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -5662,6 +5662,7 @@ SDL_ListModes(const SDL12_PixelFormat *format12, Uint32 flags)
     VideoModeList *best_modes = NULL;
     Uint32 bpp;
     int i;
+    SDL_bool windowed_mode_list = SDL12Compat_GetHintBoolean("SDL12COMPAT_WINDOWED_MODE_LIST", SDL_FALSE);
 
     if (!SDL20_WasInit(SDL_INIT_VIDEO)) {
         SDL20_SetError("Video subsystem not initialized");
@@ -5677,7 +5678,7 @@ SDL_ListModes(const SDL12_PixelFormat *format12, Uint32 flags)
         return (SDL12_Rect **) -1;  /* 1.2's dummy driver always returns -1, and it's useful to special-case that. */
     }
 
-    if (!(flags & SDL12_FULLSCREEN)) {
+    if (!windowed_mode_list && !(flags & SDL12_FULLSCREEN)) {
         return (SDL12_Rect **) -1;  /* any resolution is fine. */
     }
 


### PR DESCRIPTION
Add a new boolean hint, which makes SDL_ListModes() always return a mode list, even if the flags passed in are for windowed mode. By default, we return -1 in this case, to indicate that any mode is supported.

However, some older titles pass 0 for flags here even if they're intending to run in fullscreen, and if -1 is returned, attempt to populate their own mode list (and select a mode) themselves. For example, Civilization: Call To Power will add the current desktop mode (if it can glean it from X11, which doesn't work on Wayland, and gives an unusuable combined size for multi-monitor setups even on X11), along with the hardcoded list of 1024×768, 800×600, and 640×480).

By always returning sdl12-compat's list of modes (some of which may be "fake"), we get a much more modern list of supported modes, which allows the game to comfortably run at higher resolutions.