### PR TITLE
Treat DEBUG_INVOCATION=1 as equivalent to SDL12COMPAT_DEBUG_LOGGING=1

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1222,6 +1222,8 @@ static const char *SDL12COMPAT_GetEnvAtStartup(const char *name)
 static SDL_bool SDL12COMPAT_CheckDebugLogging(void)
 {
     const char *value = SDL12COMPAT_GetEnvAtStartup("SDL12COMPAT_DEBUG_LOGGING");
+    if (value == NULL)
+        value = SDL12COMPAT_GetEnvAtStartup("DEBUG_INVOCATION");
     return ((value != NULL) && SDL12COMPAT_strequal(value, "1")) ? SDL_TRUE : SDL_FALSE;
 }
 


### PR DESCRIPTION
In the same spirit as https://github.com/libsdl-org/SDL/issues/12275, if we enable a reasonable level of debug output whenever this variable is set, it becomes a convenient way for users to request a more verbose (but not overwhelming) amount of output. SDL 3 and GLib already do this.

Explicitly setting SDL12COMPAT_DEBUG_LOGGING=0 can override this, if it becomes necessary for whatever reason.