### PR TITLE
tweak SDL12COMPAT_strlen() / volatile hack to be c++-23 compatible.

### DIFF
--- a/src/SDL12_compat.c
+++ b/src/SDL12_compat.c
@@ -1158,11 +1158,11 @@ SDL12COMPAT_itoa(char *dst, int val)
 /* you can use SDL20_strlen once we're past startup. */
 static int SDL12COMPAT_strlen(const char *str)
 {
-    volatile int retval = 0;  /* volatile prevents gcc from optimizing this into strlen() */
-    while (str[retval]) {
-        retval++;
+    volatile const char *ptr = str;
+    while (*ptr) {
+        ++ptr;
     }
-    return retval;
+    return (int)(ptr - str);
 }
 
 /* you can use SDL20_strcmp once we're past startup. */


### PR DESCRIPTION
Reference issue: https://github.com/libsdl-org/sdl2-compat/issues/340.